### PR TITLE
bitcoin patch for miniupnpc > 1.6

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1109,10 +1109,14 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc > 1.6 */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
Hi,

I tried to compile on my centOS server the wallet but I had the following error because I use miniupnpc2.0 :

```
net.cpp: In function ‘void ThreadMapPort2(void*)’:
net.cpp:1115:74: error: invalid conversion from ‘int*’ to ‘unsigned char’ [-fpermissive]
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
                                                                          ^
net.cpp:1115:74: error: too few arguments to function ‘UPNPDev* upnpDiscover(int, const char*, const char*, int, int, unsigned char, int*)’
In file included from net.cpp:20:0:
/usr/include/miniupnpc/miniupnpc.h:62:1: note: declared here
 upnpDiscover(int delay, const char * multicastif,
 ^
make: *** [obj/net.o] Error 1
```

I found that dogecoin had the same problem so I implemented their fix.
More info here :
https://github.com/dogecoin/dogecoin/issues/1292
https://github.com/dogecoin/dogecoin/pull/1293
https://github.com/dogecoin/dogecoin/pull/1293/commits/984e204d7c60f0d0c5cc7d1c3a5daefcd7433f6e