### PR TITLE
Walletpassphrase timeout

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1455,7 +1455,14 @@ Value walletpassphrase(const Array& params, bool fHelp)
 
     NewThread(ThreadTopUpKeyPool, NULL);
     int64_t* pnSleepTime = new int64_t(params[1].get_int64());
-    NewThread(ThreadCleanWalletPassphrase, pnSleepTime);
+    if (pnSleepTime > 99999999) {
+    	throw runtime_error(
+            "walletpassphrase <passphrase> <timeout> [stakingonly]\n"
+            "Maximum timeout value is 99999999 use timeout of 0 to never re-lock");
+    }
+    if (pnSleepTime > 0) {
+        NewThread(ThreadCleanWalletPassphrase, pnSleepTime);
+    }
 
     // ppcoin: if user OS account compromised prevent trivial sendmoney commands
     if (params.size() > 2)

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1429,6 +1429,11 @@ Value walletpassphrase(const Array& params, bool fHelp)
             "walletpassphrase <passphrase> <timeout> [stakingonly]\n"
             "Stores the wallet decryption key in memory for <timeout> seconds.\n"
             "if [stakingonly] is true sending functions are disabled.");
+    if (params[1].get_int64() > 99999999 || params[1].get_int64() < 0) {
+    	throw runtime_error(
+            "walletpassphrase <passphrase> <timeout> [stakingonly]\n"
+            "Maximum timeout value is 99999999 use timeout of 0 to never re-lock, negative values not allowed");
+    }
     if (fHelp)
         return true;
     if (!pwalletMain->IsCrypted())
@@ -1455,12 +1460,7 @@ Value walletpassphrase(const Array& params, bool fHelp)
 
     NewThread(ThreadTopUpKeyPool, NULL);
     int64_t* pnSleepTime = new int64_t(params[1].get_int64());
-    if (pnSleepTime > 99999999) {
-    	throw runtime_error(
-            "walletpassphrase <passphrase> <timeout> [stakingonly]\n"
-            "Maximum timeout value is 99999999 use timeout of 0 to never re-lock");
-    }
-    if (pnSleepTime > 0) {
+    if (params[1].get_int64() > 0) {
         NewThread(ThreadCleanWalletPassphrase, pnSleepTime);
     }
 


### PR DESCRIPTION
rpc wallet unlock commands with timeout values much greater than 99999999 (over 3 years) cause our boost sleep thread to consume 100% CPU for some reason. This is not new in 1.3 nor is new to Neblio, this code was inherited from bitcoin core.

So, we limit the timeout to 99999999 seconds, and also add the option of passing 0 as a timeout which will never re-lock the wallet.

fixes #54 