### PR TITLE
Removed subtransaction ID from formatted text output (copying + csv export)

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -246,6 +246,6 @@ bool TransactionRecord::statusUpdateNeeded()
 
 std::string TransactionRecord::getTxID()
 {
-    return hash.ToString() + strprintf("-%03d", idx);
+    return hash.ToString();
 }
 


### PR DESCRIPTION
Removed subtransaction ID (output index of a transaction in an input) from being written to clipboard when copying and from CSV exports.

Closes #61.