### PR TITLE
Add import wallet option

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -957,7 +957,9 @@ void BitcoinGUI::importWallet()
                                                                 QString::fromStdString(ToString(keysAddedOutOfTotal.first)) +
                                                                 QString(" out of ") +
                                                                 QString::fromStdString(ToString(keysAddedOutOfTotal.second)) +
-                                                                QString(" added to your wallet."));
+                                                                QString(" added to your wallet. ") +
+                                                                QString(keysAddedOutOfTotal.first != keysAddedOutOfTotal.second ?
+                                                                        "\n\nKeys that are not added are usually skipped because they are already in your wallet." : ""));
         } catch(std::exception& ex) {
             QMessageBox::warning(this, "Error", "Error: " + QString::fromStdString(std::string(ex.what())));
         }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -942,7 +942,7 @@ void BitcoinGUI::importWallet()
         QString passFromDialog;
         if(IsWalletEncrypted(filename.toStdString())) {
             passFromDialog = QInputDialog::getText(this, tr("QInputDialog::getText()"),
-                                                   tr("Wallet passphrase:"), QLineEdit::Password, "", &okPressed);
+                                                   tr("Backup wallet passphrase:"), QLineEdit::Password, "", &okPressed);
             if(!okPressed) return;
             passphrase = passFromDialog.toStdString();
         }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -941,7 +941,7 @@ void BitcoinGUI::importWallet()
         bool okPressed;
         QString passFromDialog;
         if(IsWalletEncrypted(filename.toStdString())) {
-            passFromDialog = QInputDialog::getText(this, tr("QInputDialog::getText()"),
+            passFromDialog = QInputDialog::getText(this, tr("Input passphrase"),
                                                    tr("Backup wallet passphrase:"), QLineEdit::Password, "", &okPressed);
             if(!okPressed) return;
             passphrase = passFromDialog.toStdString();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -936,6 +936,16 @@ void BitcoinGUI::importWallet()
     QString openDir = QDesktopServices::storageLocation(QDesktopServices::DocumentsLocation);
     QString filename = QFileDialog::getOpenFileName(this, tr("Import Wallet"), openDir, tr("Wallet Data (*.dat)"));
     if(!filename.isEmpty()) {
+        // make sure the local wallet is unlocked
+        if (pwalletMain->IsLocked()) {
+            QMessageBox::warning(this, tr("Error"), "Please unlock the wallet before importing.");
+            return;
+        }
+        if (fWalletUnlockStakingOnly) {
+            QMessageBox::warning(this, tr("Error"), "Please unlock the wallet before importing; unlocking should NOT be for staking only.");
+            return;
+        }
+
         // get passphrase, if required
         std::string passphrase;
         bool okPressed;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -121,6 +121,7 @@ private:
     QAction *exportAction;
     QAction *encryptWalletAction;
     QAction *backupWalletAction;
+    QAction *importWalletAction;
     QAction *changePassphraseAction;
     QAction *unlockWalletAction;
     QAction *lockWalletAction;
@@ -242,6 +243,8 @@ private slots:
     void encryptWallet(bool status);
     /** Backup the wallet */
     void backupWallet();
+    /** Import a wallet */
+    void importWallet();
     /** Change encrypted wallet passphrase */
     void changePassphrase();
     /** Ask for passphrase to unlock wallet temporarily */

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -26,6 +26,10 @@ class CReserveKey;
 class COutput;
 class CCoinControl;
 
+
+std::pair<long, long> ImportBackupWallet(const std::string& Src, std::string& PassPhrase, bool importReserveToAddressBook);
+bool IsWalletEncrypted(const std::string& Src);
+
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {

--- a/src/walletdb.h
+++ b/src/walletdb.h
@@ -59,6 +59,8 @@ public:
 class CWalletDB : public CDB
 {
 public:
+    // WARNING: TODO: The fact that the filename is std::string may be a problem with non-ascii filenames, check!
+    // Keep in mind that this may work with wallet.dat, but any other name (which may come from a backup) may not work.
     CWalletDB(std::string strFilename, const char* pszMode="r+") : CDB(strFilename.c_str(), pszMode)
     {
     }


### PR DESCRIPTION
Added a wallet import option in the main menu that can use a backed up wallet. The option combines the keys from the backed up wallet with the current local wallet and resets the blockchain to the earliest key creation time.

Closes #56.