### PR TITLE
Boost 1 66 fixes

### DIFF
--- a/neblio-qt.pro
+++ b/neblio-qt.pro
@@ -47,6 +47,9 @@ OBJECTS_DIR = build
 MOC_DIR = build
 UI_DIR = build
 
+# fixes an issue with boost 1.66 and the number of template parameters of basic_socket_acceptor
+DEFINES += BOOST_ASIO_ENABLE_OLD_SERVICES
+
 # use: qmake "RELEASE=1"
 contains(RELEASE, 1) {
     # Mac: compile for maximum compatibility (10.5, 32-bit)

--- a/neblio-qt.pro
+++ b/neblio-qt.pro
@@ -49,6 +49,7 @@ UI_DIR = build
 
 # fixes an issue with boost 1.66 and the number of template parameters of basic_socket_acceptor
 DEFINES += BOOST_ASIO_ENABLE_OLD_SERVICES
+# TODO: Move to the new standard of boost as current code is deprecated
 
 # use: qmake "RELEASE=1"
 contains(RELEASE, 1) {

--- a/src/bitcoinrpc.cpp
+++ b/src/bitcoinrpc.cpp
@@ -786,8 +786,12 @@ void ThreadRPCServer2(void* parg)
     const bool fUseSSL = GetBoolArg("-rpcssl");
 
     asio::io_service io_service;
-
+#if ((BOOST_VERSION / 100000) > 1) && ((BOOST_VERSION / 100 % 1000) >= 47)
     ssl::context context(io_service, ssl::context::sslv23);
+#else
+    ssl::context context(ssl::context::sslv23);
+#endif
+
     if (fUseSSL)
     {
         context.set_options(ssl::context::no_sslv2);
@@ -803,7 +807,11 @@ void ThreadRPCServer2(void* parg)
         else printf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string().c_str());
 
         string strCiphers = GetArg("-rpcsslciphers", "TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!AH:!3DES:@STRENGTH");
+#if ((BOOST_VERSION / 100000) > 1) && ((BOOST_VERSION / 100 % 1000) >= 47)
         SSL_CTX_set_cipher_list(context.impl(), strCiphers.c_str());
+#else
+        SSL_CTX_set_cipher_list(context.native_handle(), strCiphers.c_str());
+#endif
     }
 
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
@@ -1098,7 +1106,11 @@ Object CallRPC(const string& strMethod, const Array& params)
     // Connect to localhost
     bool fUseSSL = GetBoolArg("-rpcssl");
     asio::io_service io_service;
+#if ((BOOST_VERSION / 100000) > 1) && ((BOOST_VERSION / 100 % 1000) >= 47)
     ssl::context context(io_service, ssl::context::sslv23);
+#else
+    ssl::context context(ssl::context::sslv23);
+#endif
     context.set_options(ssl::context::no_sslv2);
     asio::ssl::stream<asio::ip::tcp::socket> sslStream(io_service, context);
     SSLIOStreamDevice<asio::ip::tcp> d(sslStream, fUseSSL);


### PR DESCRIPTION
Some calls are deprecated in Boost 1.66, and they had to be fixed and tested. This branch fixes these issues.

As the complaint came from #83 with Arch Linux, this was tested with Arch Linux, which was run through docker:
```
docker run --rm -ti archimg/base-devel
```
Then the following tested the work:
```
pacman -Syy
pacman -S openssl curl qt5-base qt5-tools boost libupnp qrencode miniupnpc git python2
cd ~
git clone https://github.com/NeblioTeam/neblio
git clone https://git.afach.de/samerafach/auto-compile-openssl
cd auto-compile-openssl
python2 CompileOpenSSL-1.0.2-Linux.py    
export OPENSSL_INCLUDE_PATH_BASH=$(pwd)/openssl_build/include
export OPENSSL_LIB_PATH_BASH=$(pwd)/openssl_build/lib
cd ~
cd neblio
mkdir build
cd build
qmake "OPENSSL_INCLUDE_PATH=${OPENSSL_INCLUDE_PATH_BASH}" "OPENSSL_LIB_PATH=${OPENSSL_LIB_PATH_BASH}" ../neblio-qt.pro
make -j10
```
Remember this is necessary:
```
export LD_LIBRARY_PATH=${OPENSSL_LIB_PATH_BASH}
```
Closes #83.