### PR TITLE
Support OpenSSL 1.1

### DIFF
--- a/wallet/base58.h
+++ b/wallet/base58.h
@@ -48,7 +48,7 @@ inline std::string EncodeBase58(const unsigned char* pbegin, const unsigned char
     CBigNum rem;
     while (bn > bn0)
     {
-        if (!BN_div(&dv, &rem, &bn, &bn58, pctx))
+        if (!BN_div(dv.get_raw(), rem.get_raw(), bn.get_raw(), bn58.get_raw(), pctx))
             throw bignum_error("EncodeBase58 : BN_div failed");
         bn = dv;
         unsigned int c = rem.getulong();
@@ -95,7 +95,7 @@ inline bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet)
             break;
         }
         bnChar.setulong(p1 - pszBase58);
-        if (!BN_mul(&bn, &bn, &bn58, pctx))
+        if (!BN_mul(bn.get_raw(), bn.get_raw(), bn58.get_raw(), pctx))
             throw bignum_error("DecodeBase58 : BN_mul failed");
         bn += bnChar;
     }

--- a/wallet/bignum.h
+++ b/wallet/bignum.h
@@ -54,52 +54,59 @@ public:
 
 
 /** C++ wrapper for BIGNUM (OpenSSL bignum) */
-class CBigNum : public BIGNUM
+class CBigNum
 {
+    BIGNUM* bignum_internal;
 public:
+
     CBigNum()
     {
-        BN_init(this);
+        this->bignum_internal = BN_new();
     }
 
     CBigNum(const CBigNum& b)
     {
-        BN_init(this);
-        if (!BN_copy(this, &b))
+        this->bignum_internal = BN_new();
+        if (!BN_copy(this->bignum_internal, b.bignum_internal))
         {
-            BN_clear_free(this);
+            BN_clear_free(this->bignum_internal);
             throw bignum_error("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
         }
     }
 
     CBigNum& operator=(const CBigNum& b)
     {
-        if (!BN_copy(this, &b))
+        if (!BN_copy(this->bignum_internal, b.bignum_internal))
             throw bignum_error("CBigNum::operator= : BN_copy failed");
         return (*this);
     }
 
     ~CBigNum()
     {
-        BN_clear_free(this);
+        BN_clear_free(this->bignum_internal);
     }
 
     //CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
-    CBigNum(signed char n)        { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(short n)              { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(int n)                { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(long n)               { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(long long n)          { BN_init(this); setint64(n); }
-    CBigNum(unsigned char n)      { BN_init(this); setulong(n); }
-    CBigNum(unsigned short n)     { BN_init(this); setulong(n); }
-    CBigNum(unsigned int n)       { BN_init(this); setulong(n); }
-    CBigNum(unsigned long n)      { BN_init(this); setulong(n); }
-    CBigNum(unsigned long long n) { BN_init(this); setuint64(n); }
-    explicit CBigNum(uint256 n)   { BN_init(this); setuint256(n); }
+    CBigNum(signed char n)        { this->bignum_internal = BN_new(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(short n)              { this->bignum_internal = BN_new(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(int n)                { this->bignum_internal = BN_new(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(long n)               { this->bignum_internal = BN_new(); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(long long n)          { this->bignum_internal = BN_new(); setint64(n); }
+    CBigNum(unsigned char n)      { this->bignum_internal = BN_new(); setulong(n); }
+    CBigNum(unsigned short n)     { this->bignum_internal = BN_new(); setulong(n); }
+    CBigNum(unsigned int n)       { this->bignum_internal = BN_new(); setulong(n); }
+    CBigNum(unsigned long n)      { this->bignum_internal = BN_new(); setulong(n); }
+    CBigNum(unsigned long long n) { this->bignum_internal = BN_new(); setuint64(n); }
+    explicit CBigNum(uint256 n)   { this->bignum_internal = BN_new(); setuint256(n); }
+
+    BIGNUM* get_raw()
+    {
+        return bignum_internal;
+    }
 
     explicit CBigNum(const std::vector<unsigned char>& vch)
     {
-        BN_init(this);
+        this->bignum_internal = BN_new();
         setvch(vch);
     }
 
@@ -108,9 +115,10 @@ public:
     * @param range The upper bound on the number.
     * @return
     */
-    static CBigNum  randBignum(const CBigNum& range) {
+    static CBigNum randBignum(const CBigNum& range)
+    {
         CBigNum ret;
-        if(!BN_rand_range(&ret, &range)){
+        if(!BN_rand_range(ret.bignum_internal, range.bignum_internal)){
             throw bignum_error("CBigNum:rand element : BN_rand_range failed");
         }
         return ret;
@@ -120,9 +128,11 @@ public:
     * @param k The bit length of the number.
     * @return
     */
-    static CBigNum RandKBitBigum(const uint32_t k){
+    static CBigNum RandKBitBigum(const uint32_t k)
+    {
         CBigNum ret;
-        if(!BN_rand(&ret, k, -1, 0)){
+        if(!BN_rand(ret.bignum_internal, k, -1, 0))
+        {
             throw bignum_error("CBigNum:rand element : BN_rand failed");
         }
         return ret;
@@ -133,30 +143,30 @@ public:
      * @return the size
      */
     int bitSize() const{
-        return  BN_num_bits(this);
+        return BN_num_bits(this->bignum_internal);
     }
 
 
     void setulong(unsigned long n)
     {
-        if (!BN_set_word(this, n))
+        if (!BN_set_word(this->bignum_internal, n))
             throw bignum_error("CBigNum conversion from unsigned long : BN_set_word failed");
     }
 
     unsigned long getulong() const
     {
-        return BN_get_word(this);
+        return BN_get_word(this->bignum_internal);
     }
 
     unsigned int getuint() const
     {
-        return BN_get_word(this);
+        return BN_get_word(this->bignum_internal);
     }
 
     int getint() const
     {
-        unsigned long n = BN_get_word(this);
-        if (!BN_is_negative(this))
+        unsigned long n = BN_get_word(this->bignum_internal);
+        if (!BN_is_negative(this->bignum_internal))
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::max() : n);
         else
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::min() : -(int)n);
@@ -171,11 +181,15 @@ public:
 
         if (sn < (int64_t)0)
         {
-            // Since the minimum signed integer cannot be represented as positive so long as its type is signed, and it's not well-defined what happens if you make it unsigned before negating it, we instead increment the negative integer by 1, convert it, then increment the (now positive) unsigned integer by 1 to compensate
+            // Since the minimum signed integer cannot be represented as positive so long as its
+            // type is signed, and it's not well-defined what happens if you make it unsigned
+            // before negating it, we instead increment the negative integer by 1, convert it,
+            // then increment the (now positive) unsigned integer by 1 to compensate
             n = -(sn + 1);
             ++n;
             fNegative = true;
-        } else {
+        } else
+        {
             n = sn;
             fNegative = false;
         }
@@ -202,16 +216,16 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
-        BN_mpi2bn(pch, p - pch, this);
+        BN_mpi2bn(pch, p - pch, this->bignum_internal);
     }
 
     uint64_t getuint64()
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(this->bignum_internal, NULL);
         if (nSize < 4)
             return 0;
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(this->bignum_internal, &vch[0]);
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint64_t n = 0;
@@ -244,7 +258,7 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
-        BN_mpi2bn(pch, p - pch, this);
+        BN_mpi2bn(pch, p - pch, this->bignum_internal);
     }
 
     void setuint256(uint256 n)
@@ -272,16 +286,16 @@ public:
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize >> 0) & 0xff;
-        BN_mpi2bn(pch, p - pch, this);
+        BN_mpi2bn(pch, p - pch, this->bignum_internal);
     }
 
     uint256 getuint256() const
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(this->bignum_internal, NULL);
         if (nSize < 4)
             return 0;
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(this->bignum_internal, &vch[0]);
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint256 n = 0;
@@ -289,7 +303,6 @@ public:
             ((unsigned char*)&n)[i] = vch[j];
         return n;
     }
-
 
     void setvch(const std::vector<unsigned char>& vch)
     {
@@ -303,16 +316,16 @@ public:
         vch2[3] = (nSize >> 0) & 0xff;
         // swap data to big endian
         reverse_copy(vch.begin(), vch.end(), vch2.begin() + 4);
-        BN_mpi2bn(&vch2[0], vch2.size(), this);
+        BN_mpi2bn(&vch2[0], vch2.size(), this->bignum_internal);
     }
 
     std::vector<unsigned char> getvch() const
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(this->bignum_internal, NULL);
         if (nSize <= 4)
             return std::vector<unsigned char>();
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(this->bignum_internal, &vch[0]);
         vch.erase(vch.begin(), vch.begin() + 4);
         reverse(vch.begin(), vch.end());
         return vch;
@@ -326,16 +339,16 @@ public:
         if (nSize >= 1) vch[4] = (nCompact >> 16) & 0xff;
         if (nSize >= 2) vch[5] = (nCompact >> 8) & 0xff;
         if (nSize >= 3) vch[6] = (nCompact >> 0) & 0xff;
-        BN_mpi2bn(&vch[0], vch.size(), this);
+        BN_mpi2bn(&vch[0], vch.size(), this->bignum_internal);
         return *this;
     }
 
     unsigned int GetCompact() const
     {
-        unsigned int nSize = BN_bn2mpi(this, NULL);
+        unsigned int nSize = BN_bn2mpi(this->bignum_internal, NULL);
         std::vector<unsigned char> vch(nSize);
         nSize -= 4;
-        BN_bn2mpi(this, &vch[0]);
+        BN_bn2mpi(this->bignum_internal, &vch[0]);
         unsigned int nCompact = nSize << 24;
         if (nSize >= 1) nCompact |= (vch[4] << 16);
         if (nSize >= 2) nCompact |= (vch[5] << 8);
@@ -380,20 +393,21 @@ public:
         CBigNum bn0 = 0;
         std::string str;
         CBigNum bn = *this;
-        BN_set_negative(&bn, false);
+        BN_set_negative(bn.bignum_internal, false);
         CBigNum dv;
         CBigNum rem;
-        if (BN_cmp(&bn, &bn0) == 0)
+        if (BN_cmp(bn.bignum_internal, bn0.bignum_internal) == 0)
             return "0";
-        while (BN_cmp(&bn, &bn0) > 0)
+        while (BN_cmp(bn.bignum_internal, bn0.bignum_internal) > 0)
         {
-            if (!BN_div(&dv, &rem, &bn, &bnBase, pctx))
+            if (!BN_div(dv.bignum_internal, rem.bignum_internal, bn.bignum_internal, bnBase.bignum_internal, pctx))
                 throw bignum_error("CBigNum::ToString() : BN_div failed");
             bn = dv;
             unsigned int c = rem.getulong();
             str += "0123456789abcdef"[c];
         }
-        if (BN_is_negative(this))
+
+        if (BN_is_negative(this->bignum_internal))
             str += "-";
         reverse(str.begin(), str.end());
         return str;
@@ -440,7 +454,7 @@ public:
     CBigNum pow(const CBigNum& e) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_exp(&ret, this, &e, pctx))
+        if (!BN_exp(ret.bignum_internal, this->bignum_internal, e.bignum_internal, pctx))
             throw bignum_error("CBigNum::pow : BN_exp failed");
         return ret;
     }
@@ -453,9 +467,9 @@ public:
     CBigNum mul_mod(const CBigNum& b, const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_mod_mul(&ret, this, &b, &m, pctx))
+        if (!BN_mod_mul(ret.bignum_internal, this->bignum_internal, b.bignum_internal, m.bignum_internal, pctx))
             throw bignum_error("CBigNum::mul_mod : BN_mod_mul failed");
-        
+
         return ret;
     }
 
@@ -467,14 +481,14 @@ public:
     CBigNum pow_mod(const CBigNum& e, const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if( e < 0){
+        if (e < 0) {
             // g^-x = (g^-1)^x
             CBigNum inv = this->inverse(m);
             CBigNum posE = e * -1;
-            if (!BN_mod_exp(&ret, &inv, &posE, &m, pctx))
+            if (!BN_mod_exp(ret.bignum_internal, inv.bignum_internal, posE.bignum_internal, m.bignum_internal, pctx))
                 throw bignum_error("CBigNum::pow_mod: BN_mod_exp failed on negative exponent");
-        }else
-            if (!BN_mod_exp(&ret, this, &e, &m, pctx))
+        } else
+            if (!BN_mod_exp(ret.bignum_internal, this->bignum_internal, e.bignum_internal, m.bignum_internal, pctx))
                 throw bignum_error("CBigNum::pow_mod : BN_mod_exp failed");
 
         return ret;
@@ -489,7 +503,7 @@ public:
     CBigNum inverse(const CBigNum& m) const {
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_mod_inverse(&ret, this, &m, pctx))
+        if (!BN_mod_inverse(ret.bignum_internal, this->bignum_internal, m.bignum_internal, pctx))
             throw bignum_error("CBigNum::inverse*= :BN_mod_inverse");
         return ret;
     }
@@ -500,9 +514,10 @@ public:
      * @param safe true for a safe prime
      * @return the prime
      */
-    static CBigNum generatePrime(const unsigned int numBits, bool safe = false) {
+    static CBigNum generatePrime(const unsigned int numBits, bool safe = false)
+    {
         CBigNum ret;
-        if(!BN_generate_prime_ex(&ret, numBits, (safe == true), NULL, NULL, NULL))
+        if(!BN_generate_prime_ex(ret.bignum_internal, numBits, (safe == true), NULL, NULL, NULL))
             throw bignum_error("CBigNum::generatePrime*= :BN_generate_prime_ex");
         return ret;
     }
@@ -515,7 +530,7 @@ public:
     CBigNum gcd( const CBigNum& b) const{
         CAutoBN_CTX pctx;
         CBigNum ret;
-        if (!BN_gcd(&ret, this, &b, pctx))
+        if (!BN_gcd(ret.bignum_internal, this->bignum_internal, b.bignum_internal, pctx))
             throw bignum_error("CBigNum::gcd*= :BN_gcd");
         return ret;
     }
@@ -528,26 +543,26 @@ public:
     */
     bool isPrime(const int checks=BN_prime_checks) const {
         CAutoBN_CTX pctx;
-        int ret = BN_is_prime(this, checks, NULL, pctx, NULL);
-        if(ret < 0){
+        int ret = BN_is_prime_ex(this->bignum_internal, checks, pctx, NULL);
+        if (ret < 0) {
             throw bignum_error("CBigNum::isPrime :BN_is_prime");
         }
         return ret;
     }
 
     bool isOne() const {
-        return BN_is_one(this);
+        return BN_is_one(this->bignum_internal);
     }
 
 
     bool operator!() const
     {
-        return BN_is_zero(this);
+        return BN_is_zero(this->bignum_internal);
     }
 
     CBigNum& operator+=(const CBigNum& b)
     {
-        if (!BN_add(this, this, &b))
+        if (!BN_add(this->bignum_internal, this->bignum_internal, b.bignum_internal))
             throw bignum_error("CBigNum::operator+= : BN_add failed");
         return *this;
     }
@@ -561,7 +576,7 @@ public:
     CBigNum& operator*=(const CBigNum& b)
     {
         CAutoBN_CTX pctx;
-        if (!BN_mul(this, this, &b, pctx))
+        if (!BN_mul(this->bignum_internal, this->bignum_internal, b.bignum_internal, pctx))
             throw bignum_error("CBigNum::operator*= : BN_mul failed");
         return *this;
     }
@@ -580,7 +595,7 @@ public:
 
     CBigNum& operator<<=(unsigned int shift)
     {
-        if (!BN_lshift(this, this, shift))
+        if (!BN_lshift(this->bignum_internal, this->bignum_internal, shift))
             throw bignum_error("CBigNum:operator<<= : BN_lshift failed");
         return *this;
     }
@@ -591,13 +606,13 @@ public:
         //   if built on ubuntu 9.04 or 9.10, probably depends on version of OpenSSL
         CBigNum a = 1;
         a <<= shift;
-        if (BN_cmp(&a, this) > 0)
+        if (BN_cmp(a.bignum_internal, this->bignum_internal) > 0)
         {
             *this = 0;
             return *this;
         }
 
-        if (!BN_rshift(this, this, shift))
+        if (!BN_rshift(this->bignum_internal, this->bignum_internal, shift))
             throw bignum_error("CBigNum:operator>>= : BN_rshift failed");
         return *this;
     }
@@ -606,7 +621,7 @@ public:
     CBigNum& operator++()
     {
         // prefix operator
-        if (!BN_add(this, this, BN_value_one()))
+        if (!BN_add(this->bignum_internal, this->bignum_internal, BN_value_one()))
             throw bignum_error("CBigNum::operator++ : BN_add failed");
         return *this;
     }
@@ -623,7 +638,7 @@ public:
     {
         // prefix operator
         CBigNum r;
-        if (!BN_sub(&r, this, BN_value_one()))
+        if (!BN_sub(r.bignum_internal, this->bignum_internal, BN_value_one()))
             throw bignum_error("CBigNum::operator-- : BN_sub failed");
         *this = r;
         return *this;
@@ -637,12 +652,20 @@ public:
         return ret;
     }
 
-
+    friend inline const CBigNum operator+(const CBigNum& a, const CBigNum& b);
     friend inline const CBigNum operator-(const CBigNum& a, const CBigNum& b);
     friend inline const CBigNum operator/(const CBigNum& a, const CBigNum& b);
     friend inline const CBigNum operator%(const CBigNum& a, const CBigNum& b);
     friend inline const CBigNum operator*(const CBigNum& a, const CBigNum& b);
     friend inline bool operator<(const CBigNum& a, const CBigNum& b);
+    friend inline const CBigNum operator<<(const CBigNum& a, unsigned int shift);
+    friend inline bool operator==(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator!=(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator<=(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator>=(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator<(const CBigNum& a, const CBigNum& b);
+    friend inline bool operator>(const CBigNum& a, const CBigNum& b);
+    friend inline const CBigNum operator-(const CBigNum& a);
 };
 
 
@@ -650,7 +673,7 @@ public:
 inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
-    if (!BN_add(&r, &a, &b))
+    if (!BN_add(r.bignum_internal, a.bignum_internal, b.bignum_internal))
         throw bignum_error("CBigNum::operator+ : BN_add failed");
     return r;
 }
@@ -658,7 +681,7 @@ inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator-(const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
-    if (!BN_sub(&r, &a, &b))
+    if (!BN_sub(r.bignum_internal, a.bignum_internal, b.bignum_internal))
         throw bignum_error("CBigNum::operator- : BN_sub failed");
     return r;
 }
@@ -666,7 +689,7 @@ inline const CBigNum operator-(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator-(const CBigNum& a)
 {
     CBigNum r(a);
-    BN_set_negative(&r, !BN_is_negative(&r));
+    BN_set_negative(r.bignum_internal, !BN_is_negative(r.bignum_internal));
     return r;
 }
 
@@ -674,7 +697,7 @@ inline const CBigNum operator*(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_mul(&r, &a, &b, pctx))
+    if (!BN_mul(r.bignum_internal, a.bignum_internal, b.bignum_internal, pctx))
         throw bignum_error("CBigNum::operator* : BN_mul failed");
     return r;
 }
@@ -683,7 +706,7 @@ inline const CBigNum operator/(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_div(&r, NULL, &a, &b, pctx))
+    if (!BN_div(r.bignum_internal, NULL, a.bignum_internal, b.bignum_internal, pctx))
         throw bignum_error("CBigNum::operator/ : BN_div failed");
     return r;
 }
@@ -692,7 +715,7 @@ inline const CBigNum operator%(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_nnmod(&r, &a, &b, pctx))
+    if (!BN_nnmod(r.bignum_internal, a.bignum_internal, b.bignum_internal, pctx))
         throw bignum_error("CBigNum::operator% : BN_div failed");
     return r;
 }
@@ -700,7 +723,7 @@ inline const CBigNum operator%(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator<<(const CBigNum& a, unsigned int shift)
 {
     CBigNum r;
-    if (!BN_lshift(&r, &a, shift))
+    if (!BN_lshift(r.bignum_internal, a.bignum_internal, shift))
         throw bignum_error("CBigNum:operator<< : BN_lshift failed");
     return r;
 }
@@ -712,12 +735,12 @@ inline const CBigNum operator>>(const CBigNum& a, unsigned int shift)
     return r;
 }
 
-inline bool operator==(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) == 0); }
-inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) != 0); }
-inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) <= 0); }
-inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) >= 0); }
-inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) < 0); }
-inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) > 0); }
+inline bool operator==(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.bignum_internal, b.bignum_internal) == 0); }
+inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.bignum_internal, b.bignum_internal) != 0); }
+inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.bignum_internal, b.bignum_internal) <= 0); }
+inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.bignum_internal, b.bignum_internal) >= 0); }
+inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.bignum_internal, b.bignum_internal) < 0); }
+inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.bignum_internal, b.bignum_internal) > 0); }
 
 inline std::ostream& operator<<(std::ostream &strm, const CBigNum &b) { return strm << b.ToString(10); }
 

--- a/wallet/key.cpp
+++ b/wallet/key.cpp
@@ -78,7 +78,16 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     x = BN_CTX_get(ctx);
     if (!BN_copy(x, order)) { ret=-1; goto err; }
     if (!BN_mul_word(x, i)) { ret=-1; goto err; }
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!BN_add(x, x, ecsig->r)) { ret=-1; goto err; }
+#else
+    {
+        const BIGNUM *pr = NULL;
+        const BIGNUM *ps = NULL;
+        ECDSA_SIG_get0(ecsig, &pr, &ps);
+        if (!BN_add(x, x, pr)) { ret=-1; goto err; }
+    }
+#endif
     field = BN_CTX_get(ctx);
     if (!EC_GROUP_get_curve_GFp(group, field, NULL, NULL, ctx)) { ret=-2; goto err; }
     if (BN_cmp(x, field) >= 0) { ret=0; goto err; }
@@ -99,9 +108,27 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
     if (!BN_zero(zero)) { ret=-1; goto err; }
     if (!BN_mod_sub(e, zero, e, order, ctx)) { ret=-1; goto err; }
     rr = BN_CTX_get(ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!BN_mod_inverse(rr, ecsig->r, order, ctx)) { ret=-1; goto err; }
+#else
+    {
+        const BIGNUM *pr = NULL;
+        const BIGNUM *ps = NULL;
+        ECDSA_SIG_get0(ecsig, &pr, &ps);
+        if (!BN_mod_inverse(rr, pr, order, ctx)) { ret=-1; goto err; }
+    }
+#endif
     sor = BN_CTX_get(ctx);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (!BN_mod_mul(sor, ecsig->s, rr, order, ctx)) { ret=-1; goto err; }
+#else
+    {
+        const BIGNUM *pr = NULL;
+        const BIGNUM *ps = NULL;
+        ECDSA_SIG_get0(ecsig, &pr, &ps);
+        if (!BN_mod_mul(sor, ps, rr, order, ctx)) { ret=-1; goto err; }
+    }
+#endif
     eor = BN_CTX_get(ctx);
     if (!BN_mod_mul(eor, e, rr, order, ctx)) { ret=-1; goto err; }
     if (!EC_POINT_mul(group, Q, eor, R, sor, ctx)) { ret=-2; goto err; }
@@ -344,10 +371,23 @@ bool CKey::Sign(uint256 hash, std::vector<unsigned char>& vchSig)
     BIGNUM *halforder = BN_CTX_get(ctx);
     EC_GROUP_get_order(group, order, ctx);
     BN_rshift1(halforder, order);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     if (BN_cmp(sig->s, halforder) > 0) {
         // enforce low S values, by negating the value (modulo the order) if above order/2.
         BN_sub(sig->s, order, sig->s);
     }
+#else
+    const BIGNUM *pr = NULL;
+    const BIGNUM *ps = NULL;
+    ECDSA_SIG_get0(sig, &pr, &ps);
+    if (BN_cmp(ps, halforder) > 0) {
+        // enforce low S values, by negating the value (modulo the order) if above order/2.
+        BIGNUM *pr0 = BN_dup(pr);
+        BIGNUM *ps0 = BN_new();
+        BN_sub(ps0, order, ps);
+        ECDSA_SIG_set0(sig, pr0, ps0);
+    }
+#endif
     BN_CTX_end(ctx);
     BN_CTX_free(ctx);
     unsigned int nSize = ECDSA_size(pkey);
@@ -371,8 +411,16 @@ bool CKey::SignCompact(uint256 hash, std::vector<unsigned char>& vchSig)
         return false;
     vchSig.clear();
     vchSig.resize(65,0);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     int nBitsR = BN_num_bits(sig->r);
     int nBitsS = BN_num_bits(sig->s);
+#else
+    const BIGNUM *pr = NULL;
+    const BIGNUM *ps = NULL;
+    ECDSA_SIG_get0(sig, &pr, &ps);
+    int nBitsR = BN_num_bits(pr);
+    int nBitsS = BN_num_bits(ps);
+#endif
     if (nBitsR <= 256 && nBitsS <= 256)
     {
         int nRecId = -1;
@@ -397,8 +445,13 @@ bool CKey::SignCompact(uint256 hash, std::vector<unsigned char>& vchSig)
         }
 
         vchSig[0] = nRecId+27+(fCompressedPubKey ? 4 : 0);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         BN_bn2bin(sig->r,&vchSig[33-(nBitsR+7)/8]);
         BN_bn2bin(sig->s,&vchSig[65-(nBitsS+7)/8]);
+#else
+        BN_bn2bin(pr,&vchSig[33-(nBitsR+7)/8]);
+        BN_bn2bin(ps,&vchSig[65-(nBitsS+7)/8]);
+#endif
         fOk = true;
     }
     ECDSA_SIG_free(sig);
@@ -417,9 +470,14 @@ bool CKey::SetCompactSignature(uint256 hash, const std::vector<unsigned char>& v
     if (nV<27 || nV>=35)
         return false;
     ECDSA_SIG *sig = ECDSA_SIG_new();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     BN_bin2bn(&vchSig[1],32,sig->r);
     BN_bin2bn(&vchSig[33],32,sig->s);
-
+#else
+    BIGNUM *ecsig_r = BN_bin2bn(&vchSig[1],  32, NULL);
+    BIGNUM *ecsig_s = BN_bin2bn(&vchSig[33], 32, NULL);
+    ECDSA_SIG_set0(sig, ecsig_r, ecsig_s);
+#endif
     EC_KEY_free(pkey);
     pkey = EC_KEY_new_by_curve_name(NID_secp256k1);
     if (nV >= 31)
@@ -445,7 +503,7 @@ bool CKey::Verify(uint256 hash, const std::vector<unsigned char>& vchSigParam)
     {
         unsigned char nLengthBytes = vchSig[1] & 0x7f;
 
-        if (vchSig.size() < 2 + nLengthBytes)
+        if (vchSig.size() < (unsigned)2 + nLengthBytes)
             return false;
 
         if (nLengthBytes > 4)
@@ -454,7 +512,7 @@ bool CKey::Verify(uint256 hash, const std::vector<unsigned char>& vchSigParam)
             for (unsigned char i = 0; i < nExtraBytes; i++)
                 if (vchSig[2 + i])
                     return false;
-            vchSig.erase(vchSig.begin() + 2, vchSig.begin() + 2 + nExtraBytes);
+            vchSig.erase(vchSig.begin() + (unsigned)2, vchSig.begin() + 2 + nExtraBytes);
             vchSig[1] = 0x80 | (nLengthBytes - nExtraBytes);
         }
     }

--- a/wallet/script.cpp
+++ b/wallet/script.cpp
@@ -881,17 +881,17 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                         break;
 
                     case OP_MUL:
-                        if (!BN_mul(&bn, &bn1, &bn2, pctx))
+                        if (!BN_mul(bn.get_raw(), bn1.get_raw(), bn2.get_raw(), pctx))
                             return false;
                         break;
 
                     case OP_DIV:
-                        if (!BN_div(&bn, NULL, &bn1, &bn2, pctx))
+                        if (!BN_div(bn.get_raw(), NULL, bn1.get_raw(), bn2.get_raw(), pctx))
                             return false;
                         break;
 
                     case OP_MOD:
-                        if (!BN_mod(&bn, &bn1, &bn2, pctx))
+                        if (!BN_mod(bn.get_raw(), bn1.get_raw(), bn2.get_raw(), pctx))
                             return false;
                         break;
 

--- a/wallet/test/crypter_tests.cpp
+++ b/wallet/test/crypter_tests.cpp
@@ -1,0 +1,38 @@
+#include "googletest/googletest/include/gtest/gtest.h"
+
+#include "crypter.h"
+
+#include <boost/algorithm/hex.hpp>
+
+TEST(crypter_tests, basic_tests)
+{
+    CCrypter crypter;
+    std::string toEncrypt("Hi, this is very secret!");
+    std::vector<unsigned char> cipherText;
+    SecureString strWalletPassphrase("abc");
+    CKeyingMaterial decryptedText;
+    std::string salt("abcdefgh"); // length must be WALLET_CRYPTO_SALT_SIZE
+    std::string cipherHex;
+    std::string expectedCipherHex = "44F5DFF1856115B80ED0E7359AACC2DDF4908787D891935C7E1469E29418C52E";
+    // set encryption parameters
+    EXPECT_TRUE(crypter.SetKeyFromPassphrase(strWalletPassphrase,
+                                             std::vector<unsigned char>(salt.begin(), salt.end()),
+                                             100,
+                                             0));
+
+    // encrypt
+    EXPECT_TRUE(crypter.Encrypt(CKeyingMaterial(toEncrypt.begin(), toEncrypt.end()), cipherText));
+    boost::algorithm::hex(cipherText.begin(), cipherText.end(), std::back_inserter(cipherHex));
+
+    // make both serialized results same case for comparison
+    std::transform(cipherHex.begin(), cipherHex.end(), cipherHex.begin(), ::toupper);
+    std::transform(expectedCipherHex.begin(), expectedCipherHex.end(), expectedCipherHex.begin(), ::toupper);
+
+    // after ciphering, the string is not the same
+    EXPECT_TRUE(std::equal(cipherHex.cbegin(), cipherHex.cend(), expectedCipherHex.cbegin()));
+
+    // decrypt
+    EXPECT_TRUE(crypter.Decrypt(cipherText, decryptedText));
+    std::string decryptedTextStr(decryptedText.begin(), decryptedText.end());
+    EXPECT_EQ(decryptedTextStr, toEncrypt);
+}

--- a/wallet/test/crypter_tests.cpp
+++ b/wallet/test/crypter_tests.cpp
@@ -29,7 +29,7 @@ TEST(crypter_tests, basic_tests)
     std::transform(expectedCipherHex.begin(), expectedCipherHex.end(), expectedCipherHex.begin(), ::toupper);
 
     // after ciphering, the string is not the same
-    EXPECT_TRUE(std::equal(cipherHex.cbegin(), cipherHex.cend(), expectedCipherHex.cbegin()));
+    EXPECT_TRUE(std::equal(cipherHex.begin(), cipherHex.end(), expectedCipherHex.begin()));
 
     // decrypt
     EXPECT_TRUE(crypter.Decrypt(cipherText, decryptedText));

--- a/wallet/test/test.pro
+++ b/wallet/test/test.pro
@@ -34,6 +34,7 @@ SOURCES += \
     bloom_tests.cpp       \
     canonical_tests.cpp   \
     compress_tests.cpp    \
+    crypter_tests.cpp    \
     getarg_tests.cpp      \
     key_tests.cpp         \
     mruset_tests.cpp      \


### PR DESCRIPTION
This commit adds support for OpenSSL 1.1. So now, both OpenSSL 1.0 and 1.1 are supported and both can compile. Also a new unit-test was written for the crypter unit, which encrypts the wallet. All changes are tested. 

I'm not happy about some of the cases on how CBigNum is being used as it breaks encapsulation. For example, the object CBigNum is used in the script parser, but still, the raw openssl call for multiplication, division and modulus is still used without utilizing the CBigNum operator overloads, or at least a method from the class. This has to be addressed at some point for a cleaner code.

Closes #97.