### PR TITLE
Fix freeze on focus on amount to send

### DIFF
--- a/wallet/qt/bitcoinamountfield.cpp
+++ b/wallet/qt/bitcoinamountfield.cpp
@@ -90,12 +90,7 @@ QString BitcoinAmountField::text() const
 
 bool BitcoinAmountField::eventFilter(QObject *object, QEvent *event)
 {
-    if (event->type() == QEvent::FocusIn)
-    {
-        // Clear invalid flag on focus
-        setValid(true);
-    }
-    else if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)
+    if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)
     {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
         if (keyEvent->key() == Qt::Key_Comma)
@@ -107,6 +102,12 @@ bool BitcoinAmountField::eventFilter(QObject *object, QEvent *event)
         }
     }
     return QWidget::eventFilter(object, event);
+}
+
+void BitcoinAmountField::focusInEvent(QFocusEvent*)
+{
+    // Clear invalid flag on focus
+    setValid(true);
 }
 
 QWidget *BitcoinAmountField::setupTabChain(QWidget *prev)

--- a/wallet/qt/bitcoinamountfield.h
+++ b/wallet/qt/bitcoinamountfield.h
@@ -42,6 +42,7 @@ signals:
 protected:
     /** Intercept focus-in event and ',' key presses */
     bool eventFilter(QObject *object, QEvent *event);
+    void focusInEvent(QFocusEvent *);
 
 private:
     QDoubleSpinBox *amount;

--- a/wallet/wallet-libs.pri
+++ b/wallet/wallet-libs.pri
@@ -250,6 +250,10 @@ LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -l
 windows:LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX
 macx: LIBS += -lcurl
 
+# For Fedora
+unix:INCLUDEPATH += /usr/include/libdb4/
+unix:LIBS        += -L/usr/lib64/libdb4/
+
 contains(RELEASE, 1) {
     !windows:!macx {
         # Linux: turn dynamic linking back on for c/c++ runtime libraries


### PR DESCRIPTION
Fix freezing gui when focusing on amount. This was caused by flooding the event filter with focus events and repeatedly setting the stylesheet of the amount field.

This was tested on Fedora 27. Some dependencies were added to the qmake file to make compilation easier.

Closes #90.