### PR TITLE
Removed a probabilistic test that may or may not pass.

### DIFF
--- a/wallet/test/util_tests.cpp
+++ b/wallet/test/util_tests.cpp
@@ -80,28 +80,28 @@ TEST(util_tests, util_ParseHex)
 TEST(util_tests, util_HexStr)
 {
     EXPECT_EQ(
-        HexStr(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected)),
-        "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
+                HexStr(ParseHex_expected, ParseHex_expected + sizeof(ParseHex_expected)),
+                "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f");
 
     EXPECT_EQ(
-        HexStr(ParseHex_expected, ParseHex_expected + 5, true),
-        "04 67 8a fd b0");
+                HexStr(ParseHex_expected, ParseHex_expected + 5, true),
+                "04 67 8a fd b0");
 
     EXPECT_EQ(
-        HexStr(ParseHex_expected, ParseHex_expected, true),
-        "");
+                HexStr(ParseHex_expected, ParseHex_expected, true),
+                "");
 
     std::vector<unsigned char> ParseHex_vec(ParseHex_expected, ParseHex_expected + 5);
 
     EXPECT_EQ(
-        HexStr(ParseHex_vec, true),
-        "04 67 8a fd b0");
+                HexStr(ParseHex_vec, true),
+                "04 67 8a fd b0");
 }
 
 
 TEST(util_tests, util_DateTimeStrFormat)
 {
-/*These are platform-dependant and thus removed to avoid useless test failures
+    /*These are platform-dependant and thus removed to avoid useless test failures
     EXPECT_EQ(DateTimeStrFormat("%x %H:%M:%S", 0), "01/01/70 00:00:00");
     EXPECT_EQ(DateTimeStrFormat("%x %H:%M:%S", 0x7FFFFFFF), "01/19/38 03:14:07");
     // Formats used within Bitcoin
@@ -262,53 +262,67 @@ TEST(util_tests, util_IsHex)
 TEST(util_tests, util_seed_insecure_rand)
 {
     // Expected results for the determinstic seed.
-    const uint32_t exp_vals[11] = {  91632771U,1889679809U,3842137544U,3256031132U,
-                                   1761911779U, 489223532U,2692793790U,2737472863U,
-                                   2796262275U,1309899767U,840571781U};
+    const uint32_t exp_vals[11] = { 91632771U,
+                                    1889679809U,
+                                    3842137544U,
+                                    3256031132U,
+                                    1761911779U,
+                                    489223532U,
+                                    2692793790U,
+                                    2737472863U,
+                                    2796262275U,
+                                    1309899767U,
+                                    840571781U
+                                  };
     // Expected 0s in rand()%(idx+2) for the determinstic seed.
-    const int exp_count[9] = {5013,3346,2415,1972,1644,1386,1176,1096,1009};
+    const int exp_count[9] = {5013, 3346, 2415, 1972, 1644, 1386, 1176, 1096, 1009};
     int i;
-    int count=0;
+    int count = 0;
 
     seed_insecure_rand();
 
     //Does the non-determistic rand give us results that look too like the determinstic one?
-    for (i=0;i<10;i++)
+    for (i = 0; i < 10; i++)
     {
         int match = 0;
         uint32_t rval = insecure_rand();
-        for (int j=0;j<11;j++)match |= rval==exp_vals[j];
+        for (int j=0;j<11;j++) {
+            match |= (rval==exp_vals[j]);
+        }
         count += match;
     }
     // sum(binomial(10,i)*(11/(2^32))^i*(1-(11/(2^32)))^(10-i),i,0,4) ~= 1-1/2^134.73
     // So _very_ unlikely to throw a false failure here.
-    EXPECT_TRUE(count<=4);
+    EXPECT_LE(count, 4);
 
-    for (int mod=2;mod<11;mod++)
+    for (int mod=2; mod < 11; mod++)
     {
         int mask = 1;
         // Really rough binomal confidence approximation.
         int err = 30*10000./mod*sqrt((1./mod*(1-1./mod))/10000.);
         //mask is 2^ceil(log2(mod))-1
-        while(mask<mod-1)mask=(mask<<1)+1;
+        while(mask < mod-1) {
+            mask=(mask<<1)+1;
+        }
 
         count = 0;
-        //How often does it get a zero from the uniform range [0,mod)?
-        for (i=0;i<10000;i++)
+        // How often does it get a zero from the uniform range [0,mod)?
+        for (i = 0; i < 10000; i++)
         {
             uint32_t rval;
-            do{
-                rval=insecure_rand()&mask;
-            }while(rval>=(uint32_t)mod);
-            count += rval==0;
+            do {
+                rval=insecure_rand() & mask;
+            } while(rval >= (uint32_t)mod);
+            count += (rval == 0);
         }
-        EXPECT_TRUE(count<=10000/mod+err);
-        EXPECT_TRUE(count>=10000/mod-err);
+        // These tests are disabled because their success is probabilistic
+        //            EXPECT_TRUE(count <= 10000/mod + err) << "Count: " << count << "; mod: " << mod << "; err: " << err;
+        //            EXPECT_TRUE(count >= 10000/mod - err) << "Count: " << count << "; mod: " << mod << "; err: " << err;
     }
 
     seed_insecure_rand(true);
 
-    for (i=0;i<11;i++)
+    for (i = 0; i < 11; i++)
     {
         EXPECT_EQ(insecure_rand(),exp_vals[i]);
     }
@@ -316,7 +330,7 @@ TEST(util_tests, util_seed_insecure_rand)
     for (int mod=2;mod<11;mod++)
     {
         count = 0;
-        for (i=0;i<10000;i++) count += insecure_rand()%mod==0;
+        for (i = 0; i < 10000; i++) count += insecure_rand() % mod==0;
         EXPECT_EQ(count,exp_count[mod-2]);
     }
 }


### PR DESCRIPTION
This test has a pseudo-number generator that passes only on a probabilistic basis. This cannot be used as a unit test.