### PR TITLE
Enabled time-stamping in logging.

### DIFF
--- a/wallet/util.cpp
+++ b/wallet/util.cpp
@@ -72,7 +72,7 @@ bool fCommandLine = false;
 string strMiscWarning;
 bool fTestNet = false;
 bool fNoListen = false;
-bool fLogTimestamps = false;
+bool fLogTimestamps = true;
 CMedianFilter<int64_t> vTimeOffsets(200,0);
 bool fReopenDebugLog = false;
 


### PR DESCRIPTION
In debug.log, time stamping is now enabled.