### PR TITLE
gcc 7 fix for Ubuntu 18.04.

### DIFF
--- a/wallet/curltools.cpp
+++ b/wallet/curltools.cpp
@@ -1,5 +1,7 @@
 #include "curltools.h"
 
+#include <iostream>
+
 size_t cURLTools::CurlWrite_CallbackFunc_StdString(void *contents, size_t size,
                                         size_t nmemb, std::deque<char> *s) {
   size_t newLength = size * nmemb;


### PR DESCRIPTION
This is necessary to compile on the new version of Ubuntu.