### PR TITLE
RPC Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Open Source Repository for Neblio Nodes & Wallets
 More information here: https://nebl.io
 
-Alpha Builds for commits that pass testing can be found here:  
+Alpha Builds for commits that pass testing can be found here:
 https://neblio-build-staging.ams3.digitaloceanspaces.com/index.html
 
 Pull Requests Welcome
@@ -198,7 +198,7 @@ getaccountaddress <account>
 getaddressesbyaccount <account>
 getbalance [account] [minconf=1]
 getbestblockhash
-getblock <hash> [verbose=true]
+getblock <hash> [verbose=true] [showtxns=false]
 getblockbynumber <number> [txinfo]
 getblockcount
 getblockhash <index>

--- a/wallet/bitcoinrpc.cpp
+++ b/wallet/bitcoinrpc.cpp
@@ -1161,6 +1161,8 @@ Array RPCConvertValues(const std::string& strMethod, const std::vector<std::stri
         ConvertTo<int64_t>(params[0]);
     if (strMethod == "getblock" && n > 1)
         ConvertTo<bool>(params[1]);
+    if (strMethod == "getblock" && n > 2)
+        ConvertTo<bool>(params[2]);
     if (strMethod == "getblockbynumber" && n > 0)
         ConvertTo<int64_t>(params[0]);
     if (strMethod == "getblockbynumber" && n > 1)

--- a/wallet/rpcblockchain.cpp
+++ b/wallet/rpcblockchain.cpp
@@ -246,7 +246,7 @@ Value getblock(const Array& params, bool fHelp)
             "getblock <hash> [verbose=true]\n"
             "If verbose is false, returns a string that is serialized, hex-encoded data for block "
             "<hash>.\n"
-            "If verbose is true, returns an Object with information about block <hash>.");
+            "If verbose is true, returns an Object with information about block <hash> and information about each transaction.");
 
     std::string strHash = params[0].get_str();
     uint256     hash(strHash);
@@ -269,7 +269,7 @@ Value getblock(const Array& params, bool fHelp)
         return strHex;
     }
 
-    return blockToJSON(block, pblockindex, false);
+    return blockToJSON(block, pblockindex, true);
 }
 
 Value getblockbynumber(const Array& params, bool fHelp)

--- a/wallet/rpcblockchain.cpp
+++ b/wallet/rpcblockchain.cpp
@@ -128,7 +128,6 @@ Object blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool fPri
         if (fPrintTransactionDetail) {
             Object entry;
 
-            entry.push_back(Pair("txid", tx.GetHash().GetHex()));
             TxToJSON(tx, 0, entry);
 
             txinfo.push_back(entry);

--- a/wallet/rpcblockchain.cpp
+++ b/wallet/rpcblockchain.cpp
@@ -242,10 +242,11 @@ Value getblock(const Array& params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "getblock <hash> [verbose=true]\n"
+            "getblock <hash> [verbose=true] [showtxns=false]\n"
             "If verbose is false, returns a string that is serialized, hex-encoded data for block "
             "<hash>.\n"
-            "If verbose is true, returns an Object with information about block <hash> and information about each transaction.");
+            "If verbose is true, returns an Object with information about block <hash> .\n"
+            "If verbose is true and showtxns is true, also returns Object about each transaction.");
 
     std::string strHash = params[0].get_str();
     uint256     hash(strHash);
@@ -253,6 +254,10 @@ Value getblock(const Array& params, bool fHelp)
     bool fVerbose = true;
     if (params.size() > 1)
         fVerbose = params[1].get_bool();
+
+    bool fShowTxns = false;
+    if (params.size() > 2)
+        fShowTxns = params[2].get_bool();
 
     if (mapBlockIndex.count(hash) == 0)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
@@ -268,7 +273,7 @@ Value getblock(const Array& params, bool fHelp)
         return strHex;
     }
 
-    return blockToJSON(block, pblockindex, true);
+    return blockToJSON(block, pblockindex, fShowTxns);
 }
 
 Value getblockbynumber(const Array& params, bool fHelp)

--- a/wallet/rpcblockchain.cpp
+++ b/wallet/rpcblockchain.cpp
@@ -240,7 +240,7 @@ Value getblockhash(const Array& params, bool fHelp)
 
 Value getblock(const Array& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() < 1 || params.size() > 3)
         throw runtime_error(
             "getblock <hash> [verbose=true] [showtxns=false]\n"
             "If verbose is false, returns a string that is serialized, hex-encoded data for block "

--- a/wallet/rpcmining.cpp
+++ b/wallet/rpcmining.cpp
@@ -86,7 +86,7 @@ Value getstakinginfo(const Array& params, bool fHelp)
     	unlocked = false;
     }
     bool synced = true;
-    if (IsInitialBlockDownload_tolerant()) {
+    if (IsInitialBlockDownload()) {
     	synced = false;
     }
 

--- a/wallet/rpcmining.cpp
+++ b/wallet/rpcmining.cpp
@@ -74,10 +74,32 @@ Value getstakinginfo(const Array& params, bool fHelp)
     unsigned int nTS = TargetSpacing();
     int nExpectedTime = staking ? (nTS * nNetworkWeight / nWeight) : -1;
 
+    Object stakingCriteria;
+
+    bool matureCoins = nWeight;
+    bool activeConnection = true;
+    if (vNodes.empty()) {
+    	activeConnection = false;
+    }
+    bool unlocked = true;
+    if (pwalletMain && pwalletMain->IsLocked()) {
+    	unlocked = false;
+    }
+    bool synced = true;
+    if (IsInitialBlockDownload_tolerant()) {
+    	synced = false;
+    }
+
+    stakingCriteria.push_back(Pair("mature-coins", matureCoins));
+    stakingCriteria.push_back(Pair("wallet-unlocked", unlocked));
+    stakingCriteria.push_back(Pair("online", activeConnection));
+    stakingCriteria.push_back(Pair("synced", synced));
+
     Object obj;
 
     obj.push_back(Pair("enabled", GetBoolArg("-staking", true)));
     obj.push_back(Pair("staking", staking));
+    obj.push_back(Pair("staking-criteria", stakingCriteria));
     obj.push_back(Pair("errors", GetWarnings("statusbar")));
 
     obj.push_back(Pair("currentblocksize", (uint64_t)nLastBlockSize));

--- a/wallet/rpcrawtransaction.cpp
+++ b/wallet/rpcrawtransaction.cpp
@@ -53,6 +53,9 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
     if (isNTP1) {
         CTxDB                  txdb("r");
         FetchNTP1TxFromDisk(pair, txdb, false);
+        if (pair.second.type() == null_type ) {
+        	isNTP1 = false;
+        }
     }
     entry.push_back(Pair("txid", tx.GetHash().GetHex()));
     entry.push_back(Pair("version", tx.nVersion));

--- a/wallet/rpcrawtransaction.cpp
+++ b/wallet/rpcrawtransaction.cpp
@@ -53,7 +53,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry)
     if (isNTP1) {
         CTxDB                  txdb("r");
         FetchNTP1TxFromDisk(pair, txdb, false);
-        if (pair.second.type() == null_type ) {
+        if (pair.second.isNull()) {
         	isNTP1 = false;
         }
     }

--- a/wallet/rpcwallet.cpp
+++ b/wallet/rpcwallet.cpp
@@ -26,11 +26,8 @@ static void accountingDeprecationCheck()
             "Accounting API is deprecated and will be removed in future.\n"
             "It can easily result in negative or odd balances if misused or misunderstood, which has "
             "happened in the field.\n"
-            "If you still want to enable it, add to your config file enableaccounts=1\n");
-
-    if (GetBoolArg("-staking", true))
-        throw runtime_error("If you want to use accounting API, staking must be disabled, add to your "
-                            "config file staking=0\n");
+            "If you still want to enable it, add to your config file enableaccounts=1 and it is HIGHLY "
+            "recommended that staking is DISABLED with staking=0\n");
 }
 
 std::string HelpRequiringPassphrase()


### PR DESCRIPTION
- Enable the ability to enable Staking with Accounting API - Used by DiscordTipbot, warn users to disable staking if using accounts, as staking and the accounting API do not play nicely together unless the use case is carefully designed (like the tipbot)
- Add showtxns bool (default false) to getblock rpc command. Setting this to true puts all txn objects in the getblock output instead of just the txids. Makes explorer syncing use less RPC calls.
- Add `tokens` array to all json txn outputs (getrawtransaction, getblock, etc) to show NTP1 token inputs and outputs for all transactions.