### PR TITLE
Hide Rejected Stakes and Invalid Txns by Default

### DIFF
--- a/wallet/qt/transactionfilterproxy.cpp
+++ b/wallet/qt/transactionfilterproxy.cpp
@@ -20,7 +20,7 @@ TransactionFilterProxy::TransactionFilterProxy(QObject *parent) :
     typeFilter(ALL_TYPES),
     minAmount(0),
     limitRows(-1),
-    showInactive(true)
+    showInactive(false)
 {
 }
 

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -42,9 +42,10 @@ TransactionView::TransactionView(QWidget* parent)
     hlayout->setContentsMargins(0, 0, 0, 0);
 #ifdef Q_OS_MAC
     hlayout->setSpacing(5);
-    hlayout->addSpacing(3);
+    hlayout->addSpacing(8);
 #else
     hlayout->setSpacing(0);
+    hlayout->addSpacing(5);
 #endif
 
     showInactiveWidget = new QCheckBox(this);

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -41,13 +41,13 @@ TransactionView::TransactionView(QWidget* parent)
     QHBoxLayout* hlayout = new QHBoxLayout();
     hlayout->setContentsMargins(0, 0, 0, 0);
     showInactiveWidget = new QCheckBox(this);
+    showInactiveWidget->setEnabled(false);
+    showInactiveWidget->setToolTip("Show Conflicted & Invalid Transactions");
     hlayout->addWidget(showInactiveWidget);
 #ifdef Q_OS_MAC
     hlayout->setSpacing(5);
-    hlayout->addSpacing(26);
 #else
     hlayout->setSpacing(0);
-    hlayout->addSpacing(23);
 #endif
 
     dateWidget = new QComboBox(this);

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -13,6 +13,7 @@
 #include "walletmodel.h"
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QClipboard>
 #include <QComboBox>
 #include <QDateTimeEdit>
@@ -39,6 +40,8 @@ TransactionView::TransactionView(QWidget* parent)
 
     QHBoxLayout* hlayout = new QHBoxLayout();
     hlayout->setContentsMargins(0, 0, 0, 0);
+    showInactiveWidget = new QCheckBox(this);
+    hlayout->addWidget(showInactiveWidget);
 #ifdef Q_OS_MAC
     hlayout->setSpacing(5);
     hlayout->addSpacing(26);
@@ -143,6 +146,7 @@ TransactionView::TransactionView(QWidget* parent)
     contextMenu->addAction(viewTxInExplorer);
 
     // Connect actions
+    connect(showInactiveWidget, SIGNAL(stateChanged(int)), this, SLOT(showInactive(int)));
     connect(dateWidget, SIGNAL(activated(int)), this, SLOT(chooseDate(int)));
     connect(typeWidget, SIGNAL(activated(int)), this, SLOT(chooseType(int)));
     connect(addressWidget, SIGNAL(textChanged(QString)), this, SLOT(changedPrefix(QString)));
@@ -187,6 +191,13 @@ void TransactionView::setModel(WalletModel* model)
                                                            QHeaderView::Stretch);
         transactionView->horizontalHeader()->resizeSection(TransactionTableModel::Amount, 120);
     }
+}
+
+void TransactionView::showInactive(int state)
+{
+    if (!transactionProxyModel)
+        return;
+    transactionProxyModel->setShowInactive((state == Qt::Checked));
 }
 
 void TransactionView::chooseDate(int idx)

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -40,15 +40,15 @@ TransactionView::TransactionView(QWidget* parent)
 
     QHBoxLayout* hlayout = new QHBoxLayout();
     hlayout->setContentsMargins(0, 0, 0, 0);
-    showInactiveWidget = new QCheckBox(this);
-    showInactiveWidget->setEnabled(false);
-    showInactiveWidget->setToolTip("Show Conflicted & Invalid Transactions");
-    hlayout->addWidget(showInactiveWidget);
 #ifdef Q_OS_MAC
     hlayout->setSpacing(5);
 #else
     hlayout->setSpacing(0);
 #endif
+
+    showInactiveWidget = new QCheckBox(this);
+    showInactiveWidget->setToolTip("Show Conflicted & Invalid Transactions");
+    hlayout->addWidget(showInactiveWidget);
 
     dateWidget = new QComboBox(this);
 #ifdef Q_OS_MAC

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -42,15 +42,21 @@ TransactionView::TransactionView(QWidget* parent)
     hlayout->setContentsMargins(0, 0, 0, 0);
 #ifdef Q_OS_MAC
     hlayout->setSpacing(5);
-    hlayout->addSpacing(8);
+    hlayout->addSpacing(4);
 #else
     hlayout->setSpacing(0);
-    hlayout->addSpacing(5);
+    hlayout->addSpacing(2);
 #endif
 
     showInactiveWidget = new QCheckBox(this);
     showInactiveWidget->setToolTip("Show Conflicted & Invalid Transactions");
     hlayout->addWidget(showInactiveWidget);
+
+#ifdef Q_OS_MAC
+    hlayout->addSpacing(4);
+#else
+    hlayout->addSpacing(2);
+#endif
 
     dateWidget = new QComboBox(this);
 #ifdef Q_OS_MAC

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -45,7 +45,7 @@ TransactionView::TransactionView(QWidget* parent)
     hlayout->addSpacing(5);
 #else
     hlayout->setSpacing(0);
-    hlayout->addSpacing(3);
+    hlayout->addSpacing(2);
 #endif
 
     showInactiveWidget = new QCheckBox(this);
@@ -55,7 +55,7 @@ TransactionView::TransactionView(QWidget* parent)
 #ifdef Q_OS_MAC
     hlayout->addSpacing(5);
 #else
-    hlayout->addSpacing(3);
+    hlayout->addSpacing(2);
 #endif
 
     dateWidget = new QComboBox(this);

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -42,10 +42,10 @@ TransactionView::TransactionView(QWidget* parent)
     hlayout->setContentsMargins(0, 0, 0, 0);
 #ifdef Q_OS_MAC
     hlayout->setSpacing(5);
-    hlayout->addSpacing(4);
+    hlayout->addSpacing(5);
 #else
     hlayout->setSpacing(0);
-    hlayout->addSpacing(2);
+    hlayout->addSpacing(3);
 #endif
 
     showInactiveWidget = new QCheckBox(this);
@@ -53,9 +53,9 @@ TransactionView::TransactionView(QWidget* parent)
     hlayout->addWidget(showInactiveWidget);
 
 #ifdef Q_OS_MAC
-    hlayout->addSpacing(4);
+    hlayout->addSpacing(5);
 #else
-    hlayout->addSpacing(2);
+    hlayout->addSpacing(3);
 #endif
 
     dateWidget = new QComboBox(this);

--- a/wallet/qt/transactionview.cpp
+++ b/wallet/qt/transactionview.cpp
@@ -42,6 +42,7 @@ TransactionView::TransactionView(QWidget* parent)
     hlayout->setContentsMargins(0, 0, 0, 0);
 #ifdef Q_OS_MAC
     hlayout->setSpacing(5);
+    hlayout->addSpacing(3);
 #else
     hlayout->setSpacing(0);
 #endif

--- a/wallet/qt/transactionview.h
+++ b/wallet/qt/transactionview.h
@@ -8,6 +8,7 @@ class TransactionFilterProxy;
 
 QT_BEGIN_NAMESPACE
 class QTableView;
+class QCheckBox;
 class QComboBox;
 class QLineEdit;
 class QModelIndex;
@@ -44,6 +45,7 @@ private:
     TransactionFilterProxy* transactionProxyModel;
     QTableView*             transactionView;
 
+    QCheckBox* showInactiveWidget;
     QComboBox* dateWidget;
     QComboBox* typeWidget;
     QLineEdit* addressWidget;
@@ -72,6 +74,7 @@ signals:
     void doubleClicked(const QModelIndex&);
 
 public slots:
+    void showInactive(int state);
     void chooseDate(int idx);
     void chooseType(int idx);
     void changedPrefix(const QString& prefix);


### PR DESCRIPTION
Added a checkbox at the top of the "confirmations" column in the transactions list, that when checked, shows rejected stakes and invalid txns