### PR TITLE
Stake attack fix

### DIFF
--- a/ci_scripts/test_linux-gui_wallet.py
+++ b/ci_scripts/test_linux-gui_wallet.py
@@ -52,21 +52,25 @@ nci.call_with_err_code('python $TRAVIS_BUILD_DIR/build_scripts/CompileQREncode-L
 pkg_config_path = os.path.join(working_dir, build_dir, 'curl_build/lib/pkgconfig/')
 openssl_include_path = os.path.join(working_dir, build_dir, 'openssl_build/include/')
 openssl_lib_path = os.path.join(working_dir, build_dir, 'openssl_build/lib/')
+qrencode_lib_path = os.path.join(working_dir, build_dir, 'qrencode_build/lib/')
+qrencode_include_path = os.path.join(working_dir, build_dir, 'qrencode_build/include/')
 
 os.environ['PKG_CONFIG_PATH'] = pkg_config_path
 os.environ['OPENSSL_INCLUDE_PATH'] = openssl_include_path
 os.environ['OPENSSL_LIB_PATH'] = openssl_lib_path
+os.environ['QRENCODE_INCLUDE_PATH'] = qrencode_include_path
+os.environ['QRENCODE_LIB_PATH'] = openssl_lib_path
 
 # prepend ccache to the path, necessary since prior steps prepend things to the path
 os.environ['PATH'] = '/usr/lib/ccache:' + os.environ['PATH']
 
 if (args.test):
-	nci.call_with_err_code('qmake "USE_UPNP=1" "USE_QRCODE=1" "RELEASE=1" "OPENSSL_INCLUDE_PATH=' + openssl_include_path + '" "OPENSSL_LIB_PATH=' + openssl_lib_path + '" "PKG_CONFIG_PATH=' + pkg_config_path + '" "NEBLIO_CONFIG += NoWallet" ../neblio-wallet.pro')
+        nci.call_with_err_code('qmake "USE_UPNP=1" "USE_QRCODE=1" "RELEASE=1" "OPENSSL_INCLUDE_PATH=' + openssl_include_path + '" "OPENSSL_LIB_PATH=' + openssl_lib_path + '" "QRENCODE_LIB_PATH=' + qrencode_lib_path + '" "QRENCODE_INCLUDE_PATH=' + qrencode_include_path + '" "PKG_CONFIG_PATH=' + pkg_config_path + '" "NEBLIO_CONFIG += NoWallet" ../neblio-wallet.pro')
 	nci.call_with_err_code("make -j" + str(mp.cpu_count()))
 	# run tests
 	nci.call_with_err_code("./wallet/test/neblio-tests")
 else:
-	nci.call_with_err_code('qmake "USE_UPNP=1" "USE_QRCODE=1" "RELEASE=1" "OPENSSL_INCLUDE_PATH=' + openssl_include_path + '" "OPENSSL_LIB_PATH=' + openssl_lib_path + '" "PKG_CONFIG_PATH=' + pkg_config_path + '" ../neblio-wallet.pro')
+        nci.call_with_err_code('qmake "USE_UPNP=1" "USE_QRCODE=1" "RELEASE=1" "OPENSSL_INCLUDE_PATH=' + openssl_include_path + '" "OPENSSL_LIB_PATH=' + openssl_lib_path+ '" "QRENCODE_LIB_PATH=' + qrencode_lib_path + '" "QRENCODE_INCLUDE_PATH=' + qrencode_include_path + '" "PKG_CONFIG_PATH=' + pkg_config_path + '" ../neblio-wallet.pro')
 	nci.call_with_err_code("make -j" + str(mp.cpu_count()))
 
 	file_name = '$(date +%Y-%m-%d)---' + os.environ['TRAVIS_BRANCH'] + '-' + os.environ['TRAVIS_COMMIT'][:7] + '---neblio-Qt---ubuntu16.04.tar.gz'

--- a/wallet/ThreadSafeHashMap.h
+++ b/wallet/ThreadSafeHashMap.h
@@ -11,6 +11,8 @@ class ThreadSafeHashMap
     mutable boost::shared_mutex      mtx;
 
 public:
+    using MapType = std::unordered_map<K, V, Hasher>;
+
     ThreadSafeHashMap();
     ThreadSafeHashMap(const std::unordered_map<K, V, Hasher>& rhs);
     ThreadSafeHashMap(const ThreadSafeHashMap<K, V, Hasher>& rhs);
@@ -18,6 +20,8 @@ public:
     std::size_t                      erase(const K& key);
     void                             set(const K& key, const V& value);
     bool                             exists(const K& key) const;
+    std::size_t                      size() const;
+    bool                             empty() const;
     template <typename K_, typename V_>
     friend bool operator==(const ThreadSafeHashMap<K_, V_>& lhs, const ThreadSafeHashMap<K_, V_>& rhs);
     bool        get(const K& key, V& value) const;
@@ -87,6 +91,20 @@ bool ThreadSafeHashMap<K, V, Hasher>::exists(const K& key) const
 {
     boost::shared_lock<boost::shared_mutex> lock(mtx);
     return (theMap.find(key) != theMap.end());
+}
+
+template <typename K, typename V, typename Hasher>
+std::size_t ThreadSafeHashMap<K, V, Hasher>::size() const
+{
+    boost::shared_lock<boost::shared_mutex> lock(mtx);
+    return theMap.size();
+}
+
+template <typename K, typename V, typename Hasher>
+bool ThreadSafeHashMap<K, V, Hasher>::empty() const
+{
+    boost::shared_lock<boost::shared_mutex> lock(mtx);
+    return theMap.empty();
 }
 
 template <typename K, typename V, typename Hasher>

--- a/wallet/ThreadSafeMap.cpp
+++ b/wallet/ThreadSafeMap.cpp
@@ -1,0 +1,1 @@
+#include "ThreadSafeMap.h"

--- a/wallet/ThreadSafeMap.h
+++ b/wallet/ThreadSafeMap.h
@@ -1,0 +1,144 @@
+#ifndef THREADSAFEMAP_H
+#define THREADSAFEMAP_H
+
+#include <boost/thread.hpp>
+#include <map>
+
+template <typename K, typename V>
+class ThreadSafeMap
+{
+    std::map<K, V> theMap;
+    mutable boost::shared_mutex      mtx;
+
+public:
+    using MapType = std::map<K, V>;
+
+    ThreadSafeMap();
+    ThreadSafeMap(const std::map<K, V>& rhs);
+    ThreadSafeMap(const ThreadSafeMap<K, V>& rhs);
+    ThreadSafeMap<K, V>& operator=(const ThreadSafeMap<K, V>& rhs);
+    std::size_t                      erase(const K& key);
+    void                             set(const K& key, const V& value);
+    bool                             exists(const K& key) const;
+    std::size_t                      size() const;
+    bool                             empty() const;
+    template <typename K_, typename V_>
+    friend bool operator==(const ThreadSafeMap<K_, V_>& lhs, const ThreadSafeMap<K_, V_>& rhs);
+    bool        get(const K& key, V& value) const;
+    void        clear();
+    std::map<K, V> getInternalMap() const;
+    void                             setInternalMap(const std::map<K, V>& TheMap);
+};
+
+template <typename K, typename V>
+ThreadSafeMap<K, V>::ThreadSafeMap(const ThreadSafeMap<K, V>& rhs)
+{
+    boost::unique_lock<boost::shared_mutex> lock1(mtx);
+    boost::shared_lock<boost::shared_mutex> lock2(rhs.mtx);
+    this->theMap = rhs.theMap;
+}
+
+template <typename K, typename V>
+ThreadSafeMap<K, V>& ThreadSafeMap<K, V>::
+                                 operator=(const ThreadSafeMap<K, V>& rhs)
+{
+    boost::unique_lock<boost::shared_mutex> lock1(mtx);
+    boost::shared_lock<boost::shared_mutex> lock2(rhs.mtx);
+    this->theMap = rhs.theMap;
+    return *this;
+}
+
+template <typename K_, typename V_>
+bool operator==(const ThreadSafeMap<K_, V_>& lhs, const ThreadSafeMap<K_, V_>& rhs)
+{
+    if (&lhs == &rhs) {
+        return true;
+    }
+    boost::shared_lock<boost::shared_mutex> lock1(lhs.mtx);
+    boost::shared_lock<boost::shared_mutex> lock2(rhs.mtx);
+    return (lhs.theMap == rhs.theMap);
+}
+
+template <typename K, typename V>
+void ThreadSafeMap<K, V>::set(const K& key, const V& value)
+{
+    boost::unique_lock<boost::shared_mutex> lock(mtx);
+    theMap[key] = value;
+}
+
+template <typename K, typename V>
+bool ThreadSafeMap<K, V>::get(const K& key, V& value) const
+{
+    boost::shared_lock<boost::shared_mutex>                   lock(mtx);
+    typename std::map<K, V>::const_iterator it = theMap.find(key);
+    if (it == theMap.cend()) {
+        return false;
+    } else {
+        value = it->second;
+        return true;
+    }
+}
+
+template <typename K, typename V>
+void ThreadSafeMap<K, V>::clear()
+{
+    boost::unique_lock<boost::shared_mutex> lock(mtx);
+    theMap.clear();
+}
+
+template <typename K, typename V>
+bool ThreadSafeMap<K, V>::exists(const K& key) const
+{
+    boost::shared_lock<boost::shared_mutex> lock(mtx);
+    return (theMap.find(key) != theMap.end());
+}
+
+template <typename K, typename V>
+std::size_t ThreadSafeMap<K, V>::size() const
+{
+    boost::shared_lock<boost::shared_mutex> lock(mtx);
+    return theMap.size();
+}
+
+template <typename K, typename V>
+bool ThreadSafeMap<K, V>::empty() const
+{
+    boost::shared_lock<boost::shared_mutex> lock(mtx);
+    return theMap.empty();
+}
+
+template <typename K, typename V>
+ThreadSafeMap<K, V>::ThreadSafeMap()
+{
+}
+
+template <typename K, typename V>
+ThreadSafeMap<K, V>::ThreadSafeMap(const std::map<K, V>& rhs)
+{
+    boost::unique_lock<boost::shared_mutex> lock(mtx);
+    theMap = rhs;
+}
+
+template <typename K, typename V>
+std::size_t ThreadSafeMap<K, V>::erase(const K& key)
+{
+    boost::unique_lock<boost::shared_mutex> lock(mtx);
+    return theMap.erase(key);
+}
+
+template <typename K, typename V>
+std::map<K, V> ThreadSafeMap<K, V>::getInternalMap() const
+{
+    boost::unique_lock<boost::shared_mutex> lock(mtx);
+    std::map<K, V>        safeCopy = theMap;
+    return safeCopy;
+}
+
+template <typename K, typename V>
+void ThreadSafeMap<K, V>::setInternalMap(const std::map<K, V>& TheMap)
+{
+    boost::unique_lock<boost::shared_mutex> lock(mtx);
+    theMap = TheMap;
+}
+
+#endif // THREADSAFEMAP_H

--- a/wallet/curltools.cpp
+++ b/wallet/curltools.cpp
@@ -111,8 +111,8 @@ std::string cURLTools::GetFileFromHTTPS(const std::string& URL, long ConnectionT
             long http_response_code;
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_response_code);
             if (http_response_code != 200) {
-                throw std::runtime_error("Error retrieving data with https protocol, error code: " +
-                                         ToString(http_response_code) +
+                throw std::runtime_error("Error retrieving data with https protocol from URL \"" + URL +
+                                         "\", error code: " + ToString(http_response_code) +
                                          ". Probably the URL is invalid.");
             }
         }
@@ -214,8 +214,8 @@ std::string cURLTools::PostJsonToHTTPS(const std::string& URL, long ConnectionTi
                     throw std::runtime_error("Failed to create transaction with error: " +
                                              errorMsg.get_str());
                 } else {
-                    throw std::runtime_error("Error posting data with https protocol, error code: " +
-                                             ToString(http_response_code) +
+                    throw std::runtime_error("Error posting data with https protocol from URL \"" + URL +
+                                             "\", error code: " + ToString(http_response_code) +
                                              ". Probably the URL is invalid. Could not retrieve more "
                                              "information on the error.");
                 }

--- a/wallet/init.cpp
+++ b/wallet/init.cpp
@@ -89,7 +89,7 @@ void Shutdown(void* parg)
         bitdb.Flush(true);
         boost::filesystem::remove(GetPidFile());
         UnregisterWallet(pwalletMain);
-//        delete pwalletMain;
+        pwalletMain.reset();
         NewThread(ExitTimeout, NULL);
         MilliSleep(50);
         printf("neblio exited\n\n");
@@ -753,9 +753,9 @@ bool AppInit2()
 
     uiInterface.InitMessage(_("Loading wallet..."));
     printf("Loading wallet...\n");
-    nStart                       = GetTimeMillis();
-    bool fFirstRun               = true;
-    std::shared_ptr<CWallet> wlt = std::make_shared<CWallet>(strWalletFileName);
+    nStart                             = GetTimeMillis();
+    bool                     fFirstRun = true;
+    std::shared_ptr<CWallet> wlt       = std::make_shared<CWallet>(strWalletFileName);
     std::atomic_store(&pwalletMain, wlt);
     DBErrors nLoadWalletRet = std::atomic_load(&pwalletMain)->LoadWallet(fFirstRun);
     if (nLoadWalletRet != DB_LOAD_OK) {

--- a/wallet/main.h
+++ b/wallet/main.h
@@ -1405,6 +1405,27 @@ public:
 
     static bool CheckBIP30Attack(CTxDB& txdb, const uint256& hashTx);
 
+    struct ChainReplaceTxs
+    {
+        // transactions found in the blocks up to common ancestor in main chain
+        std::unordered_set<uint256> disconnectedRootTxs;
+        // transactions that are being spent in the above ones
+        std::unordered_map<uint256, CTxIndex> modifiedOutputsTxs;
+    };
+
+    struct CommonAncestorsMembers
+    {
+        // while finding the common ancestor, this is the part in the main chain (not part of this block)
+        std::unordered_set<uint256> inMainChain;
+        // while finding the common ancestor, this is the part of this block's chain (excluding this
+        // block)
+        std::vector<uint256>
+            inFork; // order matters here because we want to simulate respending these in order
+    };
+
+    CommonAncestorsMembers GetBlocksUpToCommonAncestorInMainChain() const;
+    ChainReplaceTxs        GetAlternateChainTxsUpToCommonAncestor(CTxDB& txdb) const;
+
     bool DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex);
     bool ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck = false);
     bool VerifyInputsUnspent(CTxDB& txdb) const;

--- a/wallet/main.h
+++ b/wallet/main.h
@@ -12,10 +12,10 @@
 #include "sync.h"
 #include "zerocoin/Zerocoin.h"
 
+#include <atomic>
 #include <list>
 #include <unordered_map>
 #include <unordered_set>
-#include <atomic>
 
 class CWallet;
 class CBlock;
@@ -1403,8 +1403,12 @@ public:
         printf("\n");
     }
 
+    static bool CheckBIP30Attack(CTxDB& txdb, const uint256& hashTx);
+
     bool DisconnectBlock(CTxDB& txdb, CBlockIndex* pindex);
     bool ConnectBlock(CTxDB& txdb, CBlockIndex* pindex, bool fJustCheck = false);
+    bool VerifyInputsUnspent(CTxDB& txdb) const;
+    bool VerifyBlock(CTxDB& txdb);
     bool ReadFromDisk(const CBlockIndex* pindex, bool fReadTransactions = true);
     bool ReadFromDisk(const CBlockIndex* pindex, CTxDB& txdb, bool fReadTransactions = true);
     bool SetBestChain(CTxDB& txdb, CBlockIndex* pindexNew, const bool createDbTransaction = true);

--- a/wallet/ntp1/ntp1script.cpp
+++ b/wallet/ntp1/ntp1script.cpp
@@ -640,6 +640,7 @@ NTP1Int NTP1Script::NTP1AmountHexToNumber(std::string hexVal)
     static_assert(digits <= 512, "Very large type for NTP1Int");
     static_assert(digits >= 64, "Very short type for NTP1Int");
 
-    return static_cast<NTP1Int>(std::bitset<digits>(mantissa).to_ullong() *
-                                std::pow(10, boost::dynamic_bitset<>(exponent).to_ulong()));
+    return static_cast<NTP1Int>(std::bitset<digits>(mantissa).to_ullong()) *
+           static_cast<NTP1Int>(
+               boost::multiprecision::pow(NTP1Int(10), boost::dynamic_bitset<>(exponent).to_ulong()));
 }

--- a/wallet/qt/ntp1/ntp1tokenlistmodel.h
+++ b/wallet/qt/ntp1/ntp1tokenlistmodel.h
@@ -44,6 +44,8 @@ class NTP1TokenListModel : public QAbstractTableModel
             }
         }
 
+        virtual ~NTP1WalletTxUpdater() {}
+
         // WalletNewTxUpdateFunctor interface
     public:
         void setReferenceBlockHeight() Q_DECL_OVERRIDE { currentBlockHeight = nBestHeight; }
@@ -69,7 +71,7 @@ public:
     void refreshNTP1Wallet();
 
     NTP1TokenListModel();
-    ~NTP1TokenListModel();
+    virtual ~NTP1TokenListModel();
     void reloadBalances();
 
     int      rowCount(const QModelIndex& parent) const Q_DECL_OVERRIDE;


### PR DESCRIPTION
Fix the stake attack issue explained in 

https://medium.com/@dsl_uiuc/fake-stake-attacks-on-chain-based-proof-of-stake-cryptocurrencies-b8b05723f806

In a nutshell, this is done by checking spent coins before writing them to disk. The check rolls back the main chain (in memory, without modifying the database) and replays the current block's chain and checks whether it's valid.