### PR TITLE
Merge to add OP_CHECKLOCKTIMEVERIFY into neblio:OP_CHECKLOCKTIMEVERIFY

### DIFF
--- a/wallet/script.cpp
+++ b/wallet/script.cpp
@@ -149,6 +149,8 @@ const char* GetOpName(opcodetype opcode)
     case OP_ENDIF                  : return "OP_ENDIF";
     case OP_VERIFY                 : return "OP_VERIFY";
     case OP_RETURN                 : return "OP_RETURN";
+    case OP_CHECKLOCKTIMEVERIFY    : return "OP_CHECKLOCKTIMEVERIFY";
+    case OP_CHECKSEQUENCEVERIFY    : return "OP_CHECKSEQUENCEVERIFY";            
 
     // stack ops
     case OP_TOALTSTACK             : return "OP_TOALTSTACK";
@@ -231,8 +233,6 @@ const char* GetOpName(opcodetype opcode)
 
     // expanson
     case OP_NOP1                   : return "OP_NOP1";
-    case OP_NOP2                   : return "OP_NOP2";
-    case OP_NOP3                   : return "OP_NOP3";
     case OP_NOP4                   : return "OP_NOP4";
     case OP_NOP5                   : return "OP_NOP5";
     case OP_NOP6                   : return "OP_NOP6";
@@ -322,6 +322,83 @@ bool IsCanonicalSignature(const valtype &vchSig) {
     return true;
 }
 
+bool CheckLockTime(const int64_t& nLockTime, const CTransaction &txTo, unsigned int nIn)
+{
+    // There are two kinds of nLockTime: lock-by-blockheight
+    // and lock-by-blocktime, distinguished by whether
+    // nLockTime < LOCKTIME_THRESHOLD.
+    //
+    // We want to compare apples to apples, so fail the script
+    // unless the type of nLockTime being tested is the same as
+    // the nLockTime in the transaction.
+    if (!(
+        (txTo.nLockTime <  LOCKTIME_THRESHOLD && nLockTime <  LOCKTIME_THRESHOLD) ||
+        (txTo.nLockTime >= LOCKTIME_THRESHOLD && nLockTime >= LOCKTIME_THRESHOLD)
+    ))
+        return false;
+
+    // Now that we know we're comparing apples-to-apples, the
+    // comparison is a simple numeric one.
+    if (nLockTime > (int64_t)txTo.nLockTime)
+        return false;
+
+    // Finally the nLockTime feature can be disabled and thus
+    // CHECKLOCKTIMEVERIFY bypassed if every txin has been
+    // finalized by setting nSequence to maxint. The
+    // transaction would be allowed into the blockchain, making
+    // the opcode ineffective.
+    //
+    // Testing if this vin is not final is sufficient to
+    // prevent this condition. Alternatively we could test all
+    // inputs, but testing just this input minimizes the data
+    // required to prove correct CHECKLOCKTIMEVERIFY execution.
+    if (SEQUENCE_FINAL == txTo.vin[nIn].nSequence)
+        return false;
+
+    return true;
+}
+
+bool CheckSequence(const int64_t& nSequence, const CTransaction &txTo, unsigned int nIn)
+{
+    // Relative lock times are supported by comparing the passed
+    // in operand to the sequence number of the input.
+    const int64_t txToSequence = (int64_t)txTo.vin[nIn].nSequence;
+
+    // Sequence numbers with their most significant bit set are not
+    // consensus constrained. Testing that the transaction's sequence
+    // number do not have this bit set prevents using this property
+    // to get around a CHECKSEQUENCEVERIFY check.
+    if (txToSequence & SEQUENCE_LOCKTIME_DISABLE_FLAG)
+        return false;
+
+    // Mask off any bits that do not have consensus-enforced meaning
+    // before doing the integer comparisons
+    const uint32_t nLockTimeMask = SEQUENCE_LOCKTIME_TYPE_FLAG | SEQUENCE_LOCKTIME_MASK;
+    const int64_t txToSequenceMasked = txToSequence & nLockTimeMask;
+    const int64_t nSequenceMasked = nSequence & nLockTimeMask;
+
+    // There are two kinds of nSequence: lock-by-blockheight
+    // and lock-by-blocktime, distinguished by whether
+    // nSequenceMasked < CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG.
+    //
+    // We want to compare apples to apples, so fail the script
+    // unless the type of nSequenceMasked being tested is the same as
+    // the nSequenceMasked in the transaction.
+    if (!(
+        (txToSequenceMasked <  SEQUENCE_LOCKTIME_TYPE_FLAG && nSequenceMasked <  SEQUENCE_LOCKTIME_TYPE_FLAG) ||
+        (txToSequenceMasked >= SEQUENCE_LOCKTIME_TYPE_FLAG && nSequenceMasked >= SEQUENCE_LOCKTIME_TYPE_FLAG)
+    )) {
+        return false;
+    }
+
+    // Now that we know we're comparing apples-to-apples, the
+    // comparison is a simple numeric one.
+    if (nSequenceMasked > txToSequenceMasked)
+        return false;
+
+    return true;
+}
+
 bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, const CTransaction& txTo, unsigned int nIn, bool fStrictEncodings, int nHashType)
 {
     CAutoBN_CTX pctx;
@@ -407,7 +484,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                 // Control
                 //
                 case OP_NOP:
-                case OP_NOP1: case OP_NOP2: case OP_NOP3: case OP_NOP4: case OP_NOP5:
+                case OP_NOP1: case OP_NOP4: case OP_NOP5:
                 case OP_NOP6: case OP_NOP7: case OP_NOP8: case OP_NOP9: case OP_NOP10:
                 break;
 
@@ -466,6 +543,66 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                 }
                 break;
 
+                case OP_CHECKLOCKTIMEVERIFY:
+                {
+                    // CHECKLOCKTIMEVERIFY
+                    //
+                    // (nLockTime -- nLockTime)
+                    if (txTo.nTime < CHECKLOCKTIME_VERIFY_SWITCH_TIME){
+                        // treat as a NOP2 if not enabled yet by timestamp
+                        break;
+                    }
+
+                    if (stack.size() < 1)
+                        return false;
+
+                    CBigNum nLockTime = CastToBigNum(stacktop(-1));
+
+                    // In the rare event that the argument may be < 0 due to
+                    // some arithmetic being done first, you can always use
+                    // 0 MAX CHECKLOCKTIMEVERIFY.
+                    if (nLockTime < 0)
+                        return false;
+
+                    // Actually compare the specified lock time with the transaction.
+                    if (!CheckLockTime(nLockTime.getuint64(), txTo, nIn))
+                        return false;
+
+                    break;
+                }
+
+                case OP_CHECKSEQUENCEVERIFY:
+                {
+                    // Not implemented
+                    // treat as a NOP3 for now as BIP68 is not implemented in Neblio
+                    break;
+
+                    if (stack.size() < 1)
+                        return false;
+
+                    // nSequence, like nLockTime, is a 32-bit unsigned integer
+                    // field. See the comment in CHECKLOCKTIMEVERIFY regarding
+                    // 5-byte numeric operands.
+                    CBigNum nSequence = CastToBigNum(stacktop(-1));
+
+                    // In the rare event that the argument may be < 0 due to
+                    // some arithmetic being done first, you can always use
+                    // 0 MAX CHECKSEQUENCEVERIFY.
+                    if (nSequence < 0)
+                        return false;
+
+                    // To provide for future soft-fork extensibility, if the
+                    // operand has the disabled lock-time flag set,
+                    // CHECKSEQUENCEVERIFY behaves as a NOP.
+                    if ((nSequence.getint() & SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0)
+                        break;
+
+                    // Compare the specified sequence number with the input.
+                    if (!CheckSequence(nSequence.getuint64(), txTo, nIn))
+                        return false;
+
+                    break;
+                }                    
 
                 //
                 // Stack ops

--- a/wallet/script.cpp
+++ b/wallet/script.cpp
@@ -360,6 +360,8 @@ bool CheckLockTime(const int64_t& nLockTime, const CTransaction &txTo, unsigned 
 
 bool CheckSequence(const int64_t& nSequence, const CTransaction &txTo, unsigned int nIn)
 {
+    // Function currently not used (NOP) due to lack of BIP68 implementation
+    
     // Relative lock times are supported by comparing the passed
     // in operand to the sequence number of the input.
     const int64_t txToSequence = (int64_t)txTo.vin[nIn].nSequence;

--- a/wallet/script.cpp
+++ b/wallet/script.cpp
@@ -150,7 +150,7 @@ const char* GetOpName(opcodetype opcode)
     case OP_VERIFY                 : return "OP_VERIFY";
     case OP_RETURN                 : return "OP_RETURN";
     case OP_CHECKLOCKTIMEVERIFY    : return "OP_CHECKLOCKTIMEVERIFY";
-    case OP_CHECKSEQUENCEVERIFY    : return "OP_CHECKSEQUENCEVERIFY";            
+    case OP_CHECKSEQUENCEVERIFY    : return "OP_CHECKSEQUENCEVERIFY"; //Currently still treated as NOP3 due to lack of BIP68 implementation            
 
     // stack ops
     case OP_TOALTSTACK             : return "OP_TOALTSTACK";
@@ -550,6 +550,11 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, co
                     // (nLockTime -- nLockTime)
                     if (txTo.nTime < CHECKLOCKTIME_VERIFY_SWITCH_TIME){
                         // treat as a NOP2 if not enabled yet by timestamp
+                        break;
+                    }
+                    
+                    //Currently, OP_CHECKLOCKTIMEVERIFY only works on testnet, otherwise still act as NOP2
+                    if(!fTestNet){
                         break;
                     }
 

--- a/wallet/script.h
+++ b/wallet/script.h
@@ -29,19 +29,19 @@ static const uint32_t SEQUENCE_FINAL = 0xffffffff;
 
 // If this flag set, CTxIn::nSequence is NOT interpreted as a
 // relative lock-time.
-static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = 0x80000000;
+static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = 0x80000000; //Constant not used currently due to lack of OP_CHECKSEQUENCEVERIFY check (NOP3) 
 
 // If CTxIn::nSequence encodes a relative lock-time and this flag
 // is set, the relative lock-time has units of 512 seconds,
 // otherwise it specifies blocks with a granularity of 1.
-static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = 0x00400000;
+static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = 0x00400000; //Constant not used currently due to lack of OP_CHECKSEQUENCEVERIFY check (NOP3)
 
 // If CTxIn::nSequence encodes a relative lock-time, this mask is
 // applied to extract that lock-time from the sequence field.
-static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff; //Constant not used currently due to lack of OP_CHECKSEQUENCEVERIFY check (NOP3)
 
 //A timestamp in the blockchain where LOCKTIME Verify Activates
-static const unsigned int CHECKLOCKTIME_VERIFY_SWITCH_TIME = 1556668800; // Wednesday, May 1, 2019 00:00:00 AM UTC
+static const unsigned int CHECKLOCKTIME_VERIFY_SWITCH_TIME = 1555977600; // Wednesday, April 23rd, 2019 00:00:00 AM UTC
 
 /** Signature hash types/flags */
 enum
@@ -121,7 +121,7 @@ enum opcodetype
     OP_VERIFY = 0x69,
     OP_RETURN = 0x6a,
     OP_CHECKLOCKTIMEVERIFY = 0xb1,
-    OP_CHECKSEQUENCEVERIFY = 0xb2,
+    OP_CHECKSEQUENCEVERIFY = 0xb2, //Currently still acts as NOP3 as OP_CHECKSEQUENCEVERIFY is not implemented
     
     // stack ops
     OP_TOALTSTACK = 0x6b,

--- a/wallet/script.h
+++ b/wallet/script.h
@@ -23,6 +23,26 @@ class CTransaction;
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
 
+// Setting nSequence to this value for every input in a transaction
+// disables nLockTime.
+static const uint32_t SEQUENCE_FINAL = 0xffffffff;
+
+// If this flag set, CTxIn::nSequence is NOT interpreted as a
+// relative lock-time.
+static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = 0x80000000;
+
+// If CTxIn::nSequence encodes a relative lock-time and this flag
+// is set, the relative lock-time has units of 512 seconds,
+// otherwise it specifies blocks with a granularity of 1.
+static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = 0x00400000;
+
+// If CTxIn::nSequence encodes a relative lock-time, this mask is
+// applied to extract that lock-time from the sequence field.
+static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+
+//A timestamp in the blockchain where LOCKTIME and SEQUENCE Verify Activate
+static const unsigned int CHECKLOCKTIME_VERIFY_SWITCH_TIME = 1556668800; // Wednesday, May 1, 2019 00:00:00 AM UTC
+
 /** Signature hash types/flags */
 enum
 {
@@ -100,7 +120,9 @@ enum opcodetype
     OP_ENDIF = 0x68,
     OP_VERIFY = 0x69,
     OP_RETURN = 0x6a,
-
+    OP_CHECKLOCKTIMEVERIFY = 0xb1,
+    OP_CHECKSEQUENCEVERIFY = 0xb2,
+    
     // stack ops
     OP_TOALTSTACK = 0x6b,
     OP_FROMALTSTACK = 0x6c,
@@ -185,8 +207,6 @@ enum opcodetype
 
     // expansion
     OP_NOP1 = 0xb0,
-    OP_NOP2 = 0xb1,
-    OP_NOP3 = 0xb2,
     OP_NOP4 = 0xb3,
     OP_NOP5 = 0xb4,
     OP_NOP6 = 0xb5,

--- a/wallet/script.h
+++ b/wallet/script.h
@@ -40,7 +40,7 @@ static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = 0x00400000;
 // applied to extract that lock-time from the sequence field.
 static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
 
-//A timestamp in the blockchain where LOCKTIME and SEQUENCE Verify Activate
+//A timestamp in the blockchain where LOCKTIME Verify Activates
 static const unsigned int CHECKLOCKTIME_VERIFY_SWITCH_TIME = 1556668800; // Wednesday, May 1, 2019 00:00:00 AM UTC
 
 /** Signature hash types/flags */

--- a/wallet/script.h
+++ b/wallet/script.h
@@ -41,7 +41,7 @@ static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = 0x00400000; //Constant not u
 static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff; //Constant not used currently due to lack of OP_CHECKSEQUENCEVERIFY check (NOP3)
 
 //A timestamp in the blockchain where LOCKTIME Verify Activates
-static const unsigned int CHECKLOCKTIME_VERIFY_SWITCH_TIME = 1555977600; // Wednesday, April 23rd, 2019 00:00:00 AM UTC
+static const unsigned int CHECKLOCKTIME_VERIFY_SWITCH_TIME = 1555977600; // Tuesday, April 23rd, 2019 00:00:00 AM UTC
 
 /** Signature hash types/flags */
 enum

--- a/wallet/test/data/script_invalid.json
+++ b/wallet/test/data/script_invalid.json
@@ -119,8 +119,10 @@
 ["2 2 LSHIFT", "8 EQUAL", "disabled"],
 ["2 1 RSHIFT", "1 EQUAL", "disabled"],
 
-["1","NOP1 NOP2 NOP3 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10 2 EQUAL"],
-["'NOP_1_to_10' NOP1 NOP2 NOP3 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10","'NOP_1_to_11' EQUAL"],
+["1","NOP1 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10 2 EQUAL"],
+["'NOP_1_to_10' NOP1 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10","'NOP_1_to_11' EQUAL"],
+
+["1 1560893090","CHECKLOCKTIMEVERIFY DROP 1 EQUAL","This will fail successfully if the transaction nLockTime is less than this unix timestamp"],
 
 ["NOP", "RIPEMD160"],
 ["NOP", "SHA1"],

--- a/wallet/test/data/script_valid.json
+++ b/wallet/test/data/script_valid.json
@@ -163,8 +163,10 @@
 ["2147483647 NEGATE DUP ADD", "-4294967294 EQUAL"],
 
 
-["1","NOP1 NOP2 NOP3 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10 1 EQUAL"],
-["'NOP_1_to_10' NOP1 NOP2 NOP3 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10","'NOP_1_to_10' EQUAL"],
+["1","NOP1 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10 1 EQUAL"],
+["'NOP_1_to_10' NOP1 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10","'NOP_1_to_10' EQUAL"],
+
+["1 1555622690","CHECKLOCKTIMEVERIFY DROP 1 EQUAL"],
 
 ["NOP",
 "'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
@@ -248,8 +250,6 @@
 ["NOP", "CODESEPARATOR 1"],
 
 ["NOP", "NOP1 1"],
-["NOP", "NOP2 1"],
-["NOP", "NOP3 1"],
 ["NOP", "NOP4 1"],
 ["NOP", "NOP5 1"],
 ["NOP", "NOP6 1"],

--- a/wallet/test/data/script_valid.json
+++ b/wallet/test/data/script_valid.json
@@ -248,7 +248,7 @@
 ["0", "HASH160"],
 ["0", "HASH256"],
 ["NOP", "CODESEPARATOR 1"],
-
+ 
 ["NOP", "NOP1 1"],
 ["NOP", "NOP4 1"],
 ["NOP", "NOP5 1"],

--- a/wallet/test/data/script_valid.json
+++ b/wallet/test/data/script_valid.json
@@ -166,7 +166,7 @@
 ["1","NOP1 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10 1 EQUAL"],
 ["'NOP_1_to_10' NOP1 NOP4 NOP5 NOP6 NOP7 NOP8 NOP9 NOP10","'NOP_1_to_10' EQUAL"],
 
-["1 1555622690","CHECKLOCKTIMEVERIFY DROP 1 EQUAL"],
+["1 1555977600","CHECKLOCKTIMEVERIFY DROP 1 EQUAL"],
 
 ["NOP",
 "'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",

--- a/wallet/test/script_tests.cpp
+++ b/wallet/test/script_tests.cpp
@@ -145,6 +145,10 @@ TEST(script_tests, script_valid)
         CScript scriptPubKey = ParseScript(scriptPubKeyString);
 
         CTransaction tx;
+        tx.nTime = CHECKLOCKTIME_VERIFY_SWITCH_TIME; //Force this transaction to use the LockTime verify by giving it a future date
+        tx.nLockTime = tx.nTime; //Match the LockTime to the nTime
+        tx.vin.resize(1); //CheckLockTimeVerify requires a nSequence to be present before it can check locktime
+        tx.vin[0].nSequence = 0; //Must also be not equal to SEQUENCE_FINAL to work      
         EXPECT_TRUE(VerifyScript(scriptSig, scriptPubKey, tx, 0, true, true, SIGHASH_NONE)) << strTest;
     }
 }
@@ -169,6 +173,10 @@ TEST(script_tests, script_invalid)
         CScript scriptPubKey = ParseScript(scriptPubKeyString);
 
         CTransaction tx;
+        tx.nTime = CHECKLOCKTIME_VERIFY_SWITCH_TIME; //Force this transaction to use the LockTime verify
+        tx.nLockTime = tx.nTime; //Match the LockTime to the nTime
+        tx.vin.resize(1); //CheckLockTimeVerify requires a nSequence to be present before it can check locktime
+        tx.vin[0].nSequence = 0; //Must also be not equal to SEQUENCE_FINAL to work      
         EXPECT_FALSE(VerifyScript(scriptSig, scriptPubKey, tx, 0, true, true, SIGHASH_NONE)) << strTest;
     }
 }

--- a/wallet/test/script_tests.cpp
+++ b/wallet/test/script_tests.cpp
@@ -148,7 +148,8 @@ TEST(script_tests, script_valid)
         tx.nTime = CHECKLOCKTIME_VERIFY_SWITCH_TIME; //Force this transaction to use the LockTime verify by giving it a future date
         tx.nLockTime = tx.nTime; //Match the LockTime to the nTime
         tx.vin.resize(1); //CheckLockTimeVerify requires a nSequence to be present before it can check locktime
-        tx.vin[0].nSequence = 0; //Must also be not equal to SEQUENCE_FINAL to work      
+        tx.vin[0].nSequence = 0; //Must also be not equal to SEQUENCE_FINAL to work       
+        fTestNet = true; //Set testnet to true as OP_CHECKLOCKTIMEVERIFY is only active on testnet for the time being
         EXPECT_TRUE(VerifyScript(scriptSig, scriptPubKey, tx, 0, true, true, SIGHASH_NONE)) << strTest;
     }
 }
@@ -177,6 +178,7 @@ TEST(script_tests, script_invalid)
         tx.nLockTime = tx.nTime; //Match the LockTime to the nTime
         tx.vin.resize(1); //CheckLockTimeVerify requires a nSequence to be present before it can check locktime
         tx.vin[0].nSequence = 0; //Must also be not equal to SEQUENCE_FINAL to work      
+        fTestNet = true; //Set testnet to true as OP_CHECKLOCKTIMEVERIFY is only active on testnet for the time being
         EXPECT_FALSE(VerifyScript(scriptSig, scriptPubKey, tx, 0, true, true, SIGHASH_NONE)) << strTest;
     }
 }


### PR DESCRIPTION
I've done the coding work to include OP_CHECKLOCKTIMEVERIFY into the neblio repository. This introduces timelocks that are important for payment channel / atomic swap script contracts. 

I've included a Unit Test for both script_valid.json and script_invalid.json that both assert correctly. I've ran the same Travis CI build settings and it builds for all OSes successfully including unit tests. The deployment timestamp is set to May 1st, 2019 at 00:00:00 UTC. I expect this will be changed.

 I've also included OP_CHECKSEQUENCEVERIFY and its associated code but it is not implemented yet as BIP68 is not supported by Neblio.