### PR TITLE
Merge to make redeemScript accept more script types

### DIFF
--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -445,7 +445,7 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
         if (whichType == TX_SCRIPTHASH) {
             if (stack.empty())
                 return false;
-            CScript                       subscript(stack.back().begin(), stack.back().end()); //Get the redeemScript
+            CScript subscript(stack.back().begin(), stack.back().end()); //Get the redeemScript
             //Removed the check to make sure the redeemScript subscript fits one of the four standard transaction types
             //Instead, make sure that the redeemScript doesn't have too many signature check Ops
             if (subscript.GetSigOpCount(true) > MAX_P2SH_SIGOPS) {

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -456,7 +456,7 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
             int nArgsExpected = ScriptSigArgsExpected(whichType, vSolutions);
             if (nArgsExpected < 0)
                 return false;
-            //If stack is smaller different than expected, not standard
+            //If stack is different than expected, not standard
             if (stack.size() != (unsigned int)nArgsExpected)
                 return false;       
         }

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -432,9 +432,6 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
         const CScript& prevScript = prev.scriptPubKey;
         if (!Solver(prevScript, whichType, vSolutions))
             return false;
-        int nArgsExpected = ScriptSigArgsExpected(whichType, vSolutions);
-        if (nArgsExpected < 0)
-            return false;
 
         // Transactions with extra stuff in their scriptSigs are
         // non-standard. Note that this EvalScript() call will
@@ -448,23 +445,22 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
         if (whichType == TX_SCRIPTHASH) {
             if (stack.empty())
                 return false;
-            CScript                       subscript(stack.back().begin(), stack.back().end());
-            vector<vector<unsigned char>> vSolutions2;
-            txnouttype                    whichType2;
-            if (!Solver(subscript, whichType2, vSolutions2))
+            CScript                       subscript(stack.back().begin(), stack.back().end()); //Get the redeemScript
+            //Removed the check to make sure the redeemScript subscript fits one of the four standard transaction types
+            //Instead, make sure that the redeemScript doesn't have too many signature check Ops
+            if (subscript.GetSigOpCount(true) > MAX_P2SH_SIGOPS) {
                 return false;
-            if (whichType2 == TX_SCRIPTHASH)
+            }            
+        }else{
+            //Not a TX_SCRIPTHASH scriptPubKey
+            int nArgsExpected = ScriptSigArgsExpected(whichType, vSolutions);
+            if (nArgsExpected < 0)
                 return false;
-
-            int tmpExpected;
-            tmpExpected = ScriptSigArgsExpected(whichType2, vSolutions2);
-            if (tmpExpected < 0)
-                return false;
-            nArgsExpected += tmpExpected;
+            //If stack is smaller different than expected, not standard
+            if (stack.size() != (unsigned int)nArgsExpected)
+                return false;       
         }
 
-        if (stack.size() != (unsigned int)nArgsExpected)
-            return false;
     }
 
     return true;

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -445,18 +445,18 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
         if (whichType == TX_SCRIPTHASH) {
             if (stack.empty())
                 return false;
-            CScript subscript(stack.back().begin(), stack.back().end()); //Get the redeemScript
-            //Removed the check to make sure the redeemScript subscript fits one of the four standard transaction types
-            //Instead, make sure that the redeemScript doesn't have too many signature check Ops
+            CScript subscript(stack.back().begin(), stack.back().end()); // Get the redeemScript
+            // Removed the check to make sure the redeemScript subscript fits one of the four standard transaction types
+            // Instead, make sure that the redeemScript doesn't have too many signature check Ops
             if (subscript.GetSigOpCount(true) > MAX_P2SH_SIGOPS) {
                 return false;
             }            
         }else{
-            //Not a TX_SCRIPTHASH scriptPubKey
+            // Not a TX_SCRIPTHASH scriptPubKey
             int nArgsExpected = ScriptSigArgsExpected(whichType, vSolutions);
             if (nArgsExpected < 0)
                 return false;
-            //If stack is different than expected, not standard
+            // If stack is different than expected, not standard
             if (stack.size() != (unsigned int)nArgsExpected)
                 return false;       
         }

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -446,21 +446,21 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
             if (stack.empty())
                 return false;
             CScript subscript(stack.back().begin(), stack.back().end()); // Get the redeemScript
-            // Removed the check to make sure the redeemScript subscript fits one of the four standard transaction types
-            // Instead, make sure that the redeemScript doesn't have too many signature check Ops
+            // Removed the check to make sure the redeemScript subscript fits one of the four standard
+            // transaction types Instead, make sure that the redeemScript doesn't have too many signature
+            // check Ops
             if (subscript.GetSigOpCount(true) > MAX_P2SH_SIGOPS) {
                 return false;
-            }            
-        }else{
+            }
+        } else {
             // Not a TX_SCRIPTHASH scriptPubKey
             int nArgsExpected = ScriptSigArgsExpected(whichType, vSolutions);
             if (nArgsExpected < 0)
                 return false;
             // If stack is different than expected, not standard
             if (stack.size() != (unsigned int)nArgsExpected)
-                return false;       
+                return false;
         }
-
     }
 
     return true;

--- a/wallet/script.h
+++ b/wallet/script.h
@@ -23,6 +23,9 @@ class CTransaction;
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
 
+/** Maximum number of signature check operations in an IsStandard() P2SH script */
+static const unsigned int MAX_P2SH_SIGOPS = 15;
+
 // Setting nSequence to this value for every input in a transaction
 // disables nLockTime.
 static const uint32_t SEQUENCE_FINAL = 0xffffffff;

--- a/wallet/test/transaction_tests.cpp
+++ b/wallet/test/transaction_tests.cpp
@@ -195,30 +195,33 @@ static std::vector<CTransaction> SetupDummyInputs(CBasicKeyStore& keystoreRet, M
     dummyTransactions[1].vout[1].nValue = 22 * CENT;
     dummyTransactions[1].vout[1].scriptPubKey.SetDestination(key[3].GetPubKey().GetID());
     inputsRet[dummyTransactions[1].GetHash()] = make_pair(CTxIndex(), dummyTransactions[1]);
-    
+
     // Add some additional dummy transactions to test flexibility of AreInputsStandard
-    // It is important to remember that AreInputsStandard doesn't actually evaluate the redeemScript itself
-    // but checks whether the format fits a preset template, in this case, less than 16 SigOps
+    // It is important to remember that AreInputsStandard doesn't actually evaluate the redeemScript
+    // itself but checks whether the format fits a preset template, in this case, less than 16 SigOps
     CScript redeemScript;
     dummyTransactions[2].vout.resize(1);
-    dummyTransactions[2].vout[0].nValue = 23 * CENT;
-    redeemScript = ParseScript("0 PICK 20 EQUALVERIFY DEPTH 3 EQUAL");
+    dummyTransactions[2].vout[0].nValue       = 23 * CENT;
+    redeemScript                              = ParseScript("0 PICK 20 EQUALVERIFY DEPTH 3 EQUAL");
     dummyTransactions[2].vout[0].scriptPubKey = GetScriptForDestination(redeemScript.GetID());
     inputsRet[dummyTransactions[2].GetHash()] = make_pair(CTxIndex(), dummyTransactions[2]);
-    
+
     dummyTransactions[3].vout.resize(1);
     dummyTransactions[3].vout[0].nValue = 23 * CENT;
     // Create scripthash with large number of sig ops but below limit (15 sig ops)
-    redeemScript = ParseScript("CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG");
+    redeemScript = ParseScript("CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG "
+                               "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG");
     dummyTransactions[3].vout[0].scriptPubKey = GetScriptForDestination(redeemScript.GetID());
-    inputsRet[dummyTransactions[3].GetHash()] = make_pair(CTxIndex(), dummyTransactions[3]);       
-    
+    inputsRet[dummyTransactions[3].GetHash()] = make_pair(CTxIndex(), dummyTransactions[3]);
+
     dummyTransactions[4].vout.resize(1);
     dummyTransactions[4].vout[0].nValue = 23 * CENT;
     // Create scripthash with too many sig ops ( > 15)
-    redeemScript = ParseScript("CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG");
+    redeemScript =
+        ParseScript("CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG "
+                    "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG");
     dummyTransactions[4].vout[0].scriptPubKey = GetScriptForDestination(redeemScript.GetID());
-    inputsRet[dummyTransactions[4].GetHash()] = make_pair(CTxIndex(), dummyTransactions[4]);     
+    inputsRet[dummyTransactions[4].GetHash()] = make_pair(CTxIndex(), dummyTransactions[4]);
 
     return dummyTransactions;
 }
@@ -254,7 +257,7 @@ TEST(transaction_tests, test_Get)
     // ... as should not having enough:
     t1.vin[0].scriptSig = CScript();
     EXPECT_TRUE(!t1.AreInputsStandard(dummyInputs));
-    
+
     // Expanded this test to include ScriptHash scripts
     // Keep in mind that AreInputsStandard is ran in conjunction with IsStandardTx (on MainNet)
     // IsStandardTx prevents transactions that have non PushData scriptsigs and scriptsigs > 500 bytes
@@ -262,34 +265,71 @@ TEST(transaction_tests, test_Get)
     CTransaction t2;
     t2.vout.resize(1);
     t2.vout[0].nValue = 20 * CENT;
-    t2.vout[0].scriptPubKey << OP_1; 
-    
+    t2.vout[0].scriptPubKey << OP_1;
+
     t2.vin.resize(1);
     t2.vin[0].prevout.hash = dummyTransactions[2].GetHash();
-    t2.vin[0].prevout.n    = 0;    
-    t2.vin[0].scriptSig = ParseScript("22 21 20"); // AreInputsStandard will return true and the script sig is true when combined with redeemScript
-    t2.vin[0].scriptSig << ToByteVector(ParseScript("0 PICK 20 EQUALVERIFY DEPTH 3 EQUAL")); // Push the redeemScript bytes
-    EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));
-    
-    t2.vin[0].scriptSig = ParseScript("22 21"); // AreInputsStandard will still return true, as we do not evaluate in AreInputsStandard
-    t2.vin[0].scriptSig << ToByteVector(ParseScript("0 PICK 20 EQUALVERIFY DEPTH 3 EQUAL")); // Push the redeemScript bytes
-    EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));
-    
-    t2.vin[0].prevout.hash = dummyTransactions[3].GetHash();
-    t2.vin[0].scriptSig = ParseScript("1"); // Create a scriptsig that will be true as it is below limit of sig ops
-    t2.vin[0].scriptSig << ToByteVector(ParseScript("CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG")); // Push the redeemScript bytes
+    t2.vin[0].prevout.n    = 0;
+    t2.vin[0].scriptSig = ParseScript("22 21 20"); // AreInputsStandard will return true and the script
+                                                   // sig is true when combined with redeemScript
+    t2.vin[0].scriptSig << ToByteVector(
+        ParseScript("0 PICK 20 EQUALVERIFY DEPTH 3 EQUAL")); // Push the redeemScript bytes
     EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));
 
-    // Create a scriptsig that be at exactly 500 bytes (limit set by IsStandardTx). AreInputsStandard will return true
-    t2.vin[0].scriptSig = ParseScript("1 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' DROP"); 
-    t2.vin[0].scriptSig << ToByteVector(ParseScript("CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG")); // Push the redeemScript bytes
-    EXPECT_EQ(t2.vin[0].scriptSig.size(),500); // Confirm that this is 500 bytes
-    EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));  
-    
+    t2.vin[0].scriptSig = ParseScript(
+        "22 21"); // AreInputsStandard will still return true, as we do not evaluate in AreInputsStandard
+    t2.vin[0].scriptSig << ToByteVector(
+        ParseScript("0 PICK 20 EQUALVERIFY DEPTH 3 EQUAL")); // Push the redeemScript bytes
+    EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));
+
+    t2.vin[0].prevout.hash = dummyTransactions[3].GetHash();
+    t2.vin[0].scriptSig =
+        ParseScript("1"); // Create a scriptsig that will be true as it is below limit of sig ops
+    t2.vin[0].scriptSig << ToByteVector(ParseScript(
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG "
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG")); // Push the redeemScript bytes
+    EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));
+
+    // Create a scriptsig that be at exactly 500 bytes (limit set by IsStandardTx). AreInputsStandard
+    // will return true
+    t2.vin[0].scriptSig =
+        ParseScript("1 "
+                    "'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' DROP");
+    t2.vin[0].scriptSig << ToByteVector(ParseScript(
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG "
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG")); // Push the redeemScript bytes
+    EXPECT_EQ(t2.vin[0].scriptSig.size(), 500u);          // Confirm that this is 500 bytes
+    EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));
+
+    // size 501 should pass, but IsStandardTx() should fail
+    t2.vin[0].scriptSig =
+        ParseScript("1 "
+                    "'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+                    "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' DROP");
+    t2.vin[0].scriptSig << ToByteVector(ParseScript(
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG "
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG")); // Push the redeemScript bytes
+    EXPECT_EQ(t2.vin[0].scriptSig.size(), 501u);          // Confirm that this is 501 bytes
+    EXPECT_TRUE(t2.AreInputsStandard(dummyInputs));
+    std::string reason;
+    EXPECT_FALSE(IsStandardTx(t2, reason));
+
     t2.vin[0].prevout.hash = dummyTransactions[4].GetHash();
-    t2.vin[0].scriptSig = ParseScript("1"); // Create a scriptsig that will make AreInputsStandard return false due to too many sig ops
-    t2.vin[0].scriptSig << ToByteVector(ParseScript("CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG")); // Push the redeemScript bytes
-    EXPECT_TRUE(!t2.AreInputsStandard(dummyInputs));      
+    t2.vin[0].scriptSig    = ParseScript(
+        "1"); // Create a scriptsig that will make AreInputsStandard return false due to too many sig ops
+    t2.vin[0].scriptSig << ToByteVector(ParseScript(
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG "
+        "CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG CHECKSIG")); // Push the redeemScript bytes
+    EXPECT_FALSE(t2.AreInputsStandard(dummyInputs));
 }
 
 TEST(transaction_tests, test_GetThrow)

--- a/wallet/test/transaction_tests.cpp
+++ b/wallet/test/transaction_tests.cpp
@@ -172,7 +172,7 @@ std::vector<unsigned char> ToByteVector(const T& in)
 static std::vector<CTransaction> SetupDummyInputs(CBasicKeyStore& keystoreRet, MapPrevTx& inputsRet)
 {
     std::vector<CTransaction> dummyTransactions;
-    dummyTransactions.resize(2);
+    dummyTransactions.resize(5);
 
     // Add some keys to the keystore:
     CKey key[4];


### PR DESCRIPTION
Currently, the redeemScript can be one of four types: p2pk, p2pkh, multisig, nulldata or the transaction cannot be relayed. This is severely limiting and doesn't allow for use for other OP codes (such as the newly implemented CLTV or OP_IF) as they are considered non-standard.

What this pull request does is make the definition of a standard redeemScript more broad to allow any OP_CODE that is not disabled. Instead, the amount of signature check OP_CODES are restricted to prevent DoS. This is similar to how Bitcoin now processes transaction inputs: https://github.com/bitcoin/bitcoin/blob/master/src/policy/policy.cpp#L160

Pull request should pass Travis CI and I've already tested a binary of the source code that works with such a transaction on Mainnet.