### PR TITLE
Merge to fix a potential crash that may occur with invalid ScriptSigs from Scripthash addresses

### DIFF
--- a/wallet/script.cpp
+++ b/wallet/script.cpp
@@ -1857,6 +1857,9 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     {
         if (!scriptSig.IsPushOnly()) // scriptSig must be literals-only
             return false;            // or validation fails
+        
+        if (stackCopy.empty()) //Check to make sure that the stackCopy has elements too
+            return false;         
 
         const valtype& pubKeySerialized = stackCopy.back();
         CScript pubKey2(pubKeySerialized.begin(), pubKeySerialized.end());

--- a/wallet/script.cpp
+++ b/wallet/script.cpp
@@ -1858,7 +1858,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         if (!scriptSig.IsPushOnly()) // scriptSig must be literals-only
             return false;            // or validation fails
         
-        if (stackCopy.empty()) //Check to make sure that the stackCopy has elements too
+        if (stackCopy.empty()) // Check to make sure that the stackCopy has elements too
             return false;         
 
         const valtype& pubKeySerialized = stackCopy.back();


### PR DESCRIPTION
While testing on Testnet, I accidentally created a transaction that would crash my node when using sendrawtransaction. I researched and pinpointed the issue to a small part of VerifyScript that didn't verify if the stackCopy existed before using it.