### PR TITLE
Optimize VIU

### DIFF
--- a/wallet/block.h
+++ b/wallet/block.h
@@ -112,20 +112,19 @@ public:
 
     struct ChainReplaceTxs
     {
-        // transactions found in the blocks up to common ancestor in main chain
-        std::unordered_set<uint256> disconnectedRootTxs;
         // transactions that are being spent in the above ones
         std::unordered_map<uint256, CTxIndex> modifiedOutputsTxs;
+        // the common ancestor block between the new fork of the new block and the main chain
+        CBlockIndexSmartPtr commonAncestorBlockIndex;
     };
 
     struct CommonAncestorSuccessorBlocks
     {
-        // while finding the common ancestor, this is the part in the main chain (not part of this block)
-        std::unordered_set<uint256> inMainChain;
         // while finding the common ancestor, this is the part of this block's chain (excluding this
         // block)
         std::vector<uint256>
             inFork; // order matters here because we want to simulate respending these in order
+        CBlockIndexSmartPtr commonAncestor;
     };
 
     CommonAncestorSuccessorBlocks GetBlocksUpToCommonAncestorInMainChain() const;

--- a/wallet/main.h
+++ b/wallet/main.h
@@ -99,7 +99,7 @@ extern bool fEnforceCanonical;
 class NTP1Transaction;
 
 // Minimum disk space required - used in CheckDiskSpace()
-static const uint64_t nMinDiskSpace = 52428800;
+static const std::uintmax_t nMinDiskSpace = 52428800;
 
 class CReserveKey;
 class CTxDB;
@@ -110,7 +110,7 @@ void         UnregisterWallet(std::shared_ptr<CWallet> pwalletIn);
 void         SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL, bool fUpdate = false,
                              bool fConnect = true);
 bool         ProcessBlock(CNode* pfrom, CBlock* pblock);
-bool         CheckDiskSpace(uint64_t nAdditionalBytes = 0);
+bool         CheckDiskSpace(uintmax_t nAdditionalBytes = 0);
 bool         LoadBlockIndex(bool fAllowNew = true);
 void         PrintBlockTree();
 bool         ProcessMessages(CNode* pfrom);


### PR DESCRIPTION
Optimize VerifyInputsUnspent by making them not require to rewind the whole main chain, but simply find the relevant transactions and unspend them.

This is based on RestructureSource, which is based on master.
