### PR TITLE
Switch Download Counter to show download progress in MB instead of %

### DIFF
--- a/wallet/curltools.cpp
+++ b/wallet/curltools.cpp
@@ -71,8 +71,8 @@ int cURLTools::CurlAtomicProgress_CallbackFunc(void* number, double TotalToDownl
 {
     std::atomic<float>* progress = reinterpret_cast<std::atomic<float>*>(number);
     float               val      = 0;
-    if (TotalToDownload > 0.) {
-        val = static_cast<float>(100. * NowDownloaded / TotalToDownload);
+    if (NowDownloaded > 0.) {
+        val = static_cast<float>( NowDownloaded / 1000 / 1000); // bytes to MB
         if (val < 0.0001) {
             val = 0;
         }

--- a/wallet/txdb-lmdb.cpp
+++ b/wallet/txdb-lmdb.cpp
@@ -268,7 +268,7 @@ void DownloadQuickSyncFile(const json_spirit::Value& fileVal, const filesystem::
         std::stringstream ss;
         ss.setf(std::ios::fixed);
         ss << "Downloading QuickSync file " << leaf << ": " << std::setprecision(2)
-           << progress.load(std::memory_order_relaxed) << "%...";
+           << progress.load(std::memory_order_relaxed) << " MB...";
         uiInterface.InitMessage(ss.str());
     } while (downloadThreadFuture.wait_for(boost::chrono::milliseconds(250)) !=
              boost::future_status::ready);


### PR DESCRIPTION
This is due to the fact our new QuickSync server uses chunked encoding and does not return the content-length to cURL. One day we could use the file size from the JSON file to calculate the download percentage, but that is not being done today.