### PR TITLE
Updated the algorithm that checks whether the lmdb map requires resizing

### DIFF
--- a/wallet/block.cpp
+++ b/wallet/block.cpp
@@ -1487,7 +1487,7 @@ bool CBlock::WriteToDisk(const uint256& nBlockPos, const uint256& hashProof)
      */
 
     CTxDB       txdb;
-    std::size_t req_size = 500 * ::GetSerializeSize(*this, SER_DISK, CLIENT_VERSION);
+    std::size_t req_size = 1000 * ::GetSerializeSize(*this, SER_DISK, CLIENT_VERSION);
     if (!txdb.TxnBegin(req_size)) {
         printf("Failed to start transaction for writing a new block.");
         return false;


### PR DESCRIPTION
to prevent small resizes, which increase the likelihood of a failed
resize during a transaction. There's a minimum resize increase amount
now.