### PR TITLE
System tests wallet update validation state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ add_library(core_lib STATIC
     wallet/stakemaker.cpp
     wallet/work.cpp
     wallet/addressbook.cpp
+    wallet/validation.cpp
     )
 
 target_link_libraries(core_lib

--- a/test/functional/feature_pos.py
+++ b/test/functional/feature_pos.py
@@ -212,12 +212,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         test_maturity_rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
         test_maturity_signed_rawtx = self.nodes[3].signrawtransaction(test_maturity_rawtx)
         for node in self.nodes:  # spending stake before maturity should be rejected in all nodes
-            assert_raises_rpc_error(-26, "TX rejected", node.sendrawtransaction, test_maturity_signed_rawtx['hex'])
+            assert_raises_rpc_error(-26, "input-connect-error", node.sendrawtransaction, test_maturity_signed_rawtx['hex'])
 
         # we stake blocks that total to 'COINBASE_MATURITY' blocks, and the staked block to mature
         for i in range(COINBASE_MATURITY):
             # it should not be possible to submit the transaction until the maturity is reached
-            assert_raises_rpc_error(-26, "TX rejected", self.nodes[0].sendrawtransaction,
+            assert_raises_rpc_error(-26, "input-connect-error", self.nodes[0].sendrawtransaction,
                                     test_maturity_signed_rawtx['hex'])
             hash = self.gen_pos_block(0)
         self.sync_all()

--- a/test/functional/feature_pos.py
+++ b/test/functional/feature_pos.py
@@ -212,12 +212,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         test_maturity_rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
         test_maturity_signed_rawtx = self.nodes[3].signrawtransaction(test_maturity_rawtx)
         for node in self.nodes:  # spending stake before maturity should be rejected in all nodes
-            assert_raises_rpc_error(-26, "input-connect-error", node.sendrawtransaction, test_maturity_signed_rawtx['hex'])
+            assert_raises_rpc_error(-26, "bad-txns-premature-spend-of-coinstake", node.sendrawtransaction, test_maturity_signed_rawtx['hex'])
 
         # we stake blocks that total to 'COINBASE_MATURITY' blocks, and the staked block to mature
         for i in range(COINBASE_MATURITY):
             # it should not be possible to submit the transaction until the maturity is reached
-            assert_raises_rpc_error(-26, "input-connect-error", self.nodes[0].sendrawtransaction,
+            assert_raises_rpc_error(-26, "bad-txns-premature-spend-of-coinstake", self.nodes[0].sendrawtransaction,
                                     test_maturity_signed_rawtx['hex'])
             hash = self.gen_pos_block(0)
         self.sync_all()

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -240,8 +240,7 @@ class ColdStakingTest(BitcoinTestFramework):
         # this is not usable due to the unavailability of validation state
         # assert_raises_rpc_error(-26, "mandatory-script-verify-flag-failed (Script failed an OP_CHECKCOLDSTAKEVERIFY operation",
         #                         self.spendUTXOwithNode, u, 1)
-        assert_raises_rpc_error(-26, "TX rejected",
-                                self.spendUTXOwithNode, u, 1)
+        assert_raises_rpc_error(-26, "input-connect-error", self.spendUTXOwithNode, u, 1)
         self.log.info("Good. Cold staker was NOT able to spend (failed OP_CHECKCOLDSTAKEVERIFY)")
         for i in range(30):
             hash = self.gen_pow_block(3, average_block_time, block_time_spread)

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -240,7 +240,7 @@ class ColdStakingTest(BitcoinTestFramework):
         # this is not usable due to the unavailability of validation state
         # assert_raises_rpc_error(-26, "mandatory-script-verify-flag-failed (Script failed an OP_CHECKCOLDSTAKEVERIFY operation",
         #                         self.spendUTXOwithNode, u, 1)
-        assert_raises_rpc_error(-26, "input-connect-error", self.spendUTXOwithNode, u, 1)
+        assert_raises_rpc_error(-26, "mandatory-script-verify-flag-failed", self.spendUTXOwithNode, u, 1)
         self.log.info("Good. Cold staker was NOT able to spend (failed OP_CHECKCOLDSTAKEVERIFY)")
         for i in range(30):
             hash = self.gen_pow_block(3, average_block_time, block_time_spread)

--- a/test/functional/mining_pos_coldStaking.py
+++ b/test/functional/mining_pos_coldStaking.py
@@ -238,9 +238,8 @@ class ColdStakingTest(BitcoinTestFramework):
         assert_greater_than(len(delegated_utxos), 0)
         u = delegated_utxos[0]
         # this is not usable due to the unavailability of validation state
-        # assert_raises_rpc_error(-26, "mandatory-script-verify-flag-failed (Script failed an OP_CHECKCOLDSTAKEVERIFY operation",
-        #                         self.spendUTXOwithNode, u, 1)
-        assert_raises_rpc_error(-26, "mandatory-script-verify-flag-failed", self.spendUTXOwithNode, u, 1)
+        assert_raises_rpc_error(-26, "mandatory-script-verify-flag-failed (Script failed an OP_CHECKCOLDSTAKEVERIFY operation)",
+                                self.spendUTXOwithNode, u, 1)
         self.log.info("Good. Cold staker was NOT able to spend (failed OP_CHECKCOLDSTAKEVERIFY)")
         for i in range(30):
             hash = self.gen_pow_block(3, average_block_time, block_time_spread)

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -155,7 +155,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[2].signrawtransaction(rawtx)
 
         # This will raise an exception since there are missing inputs
-        assert_raises_rpc_error(-25, "Missing inputs", self.nodes[2].sendrawtransaction, rawtx['hex'])
+        assert_raises_rpc_error(-25, "bad-txns-inputs-missingorspent", self.nodes[2].sendrawtransaction, rawtx['hex'])
 
         #####################################
         # getrawtransaction with block hash #

--- a/wallet/amount.h
+++ b/wallet/amount.h
@@ -27,6 +27,6 @@ static const std::string CURRENCY_UNIT = "NEBL";
 // Total coin that will be released (~infinite);
 static const CAmount MAX_MONEY = std::numeric_limits<int64_t>::max();
 
-inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
+inline bool MoneyRange(CAmount nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 #endif //  BITCOIN_AMOUNT_H

--- a/wallet/bitcoinrpc.h
+++ b/wallet/bitcoinrpc.h
@@ -44,20 +44,24 @@ enum RPCErrorCode
     RPC_PARSE_ERROR      = -32700,
 
     // General application defined errors
-    RPC_MISC_ERROR             = -1,  // std::exception thrown in command handling
-    RPC_FORBIDDEN_BY_SAFE_MODE = -2,  // Server is in safe mode, and command is not allowed in safe mode
-    RPC_TYPE_ERROR             = -3,  // Unexpected type was passed as parameter
-    RPC_INVALID_ADDRESS_OR_KEY = -5,  // Invalid address or key
-    RPC_OUT_OF_MEMORY          = -7,  // Ran out of memory during operation
-    RPC_INVALID_PARAMETER      = -8,  // Invalid, missing or duplicate parameter
-    RPC_DATABASE_ERROR         = -20, // Database error
-    RPC_DESERIALIZATION_ERROR  = -22, // Error parsing or validating structure in raw format
-    RPC_TX_AMEND_FAILED        = -23, // Error parsing or validating structure in raw format
-    RPC_VERIFY_ERROR           = -25, // General error during transaction or block submission
-    RPC_VERIFY_REJECTED        = -26, //! Transaction or block was rejected by network rules
+    RPC_MISC_ERROR              = -1,  // std::exception thrown in command handling
+    RPC_FORBIDDEN_BY_SAFE_MODE  = -2,  // Server is in safe mode, and command is not allowed in safe mode
+    RPC_TYPE_ERROR              = -3,  // Unexpected type was passed as parameter
+    RPC_INVALID_ADDRESS_OR_KEY  = -5,  // Invalid address or key
+    RPC_OUT_OF_MEMORY           = -7,  // Ran out of memory during operation
+    RPC_INVALID_PARAMETER       = -8,  // Invalid, missing or duplicate parameter
+    RPC_DATABASE_ERROR          = -20, // Database error
+    RPC_DESERIALIZATION_ERROR   = -22, // Error parsing or validating structure in raw format
+    RPC_TX_AMEND_FAILED         = -23, // Error parsing or validating structure in raw format
+    RPC_VERIFY_ERROR            = -25, // General error during transaction or block submission
+    RPC_VERIFY_REJECTED         = -26, //  Transaction or block was rejected by network rules
+    RPC_VERIFY_ALREADY_IN_CHAIN = -27, // Transaction already in chain
+    RPC_IN_WARMUP               = -28, // Client still warming up
 
     //! Aliases for backward compatibility
-    RPC_TRANSACTION_ERROR = RPC_VERIFY_ERROR,
+    RPC_TRANSACTION_ERROR            = RPC_VERIFY_ERROR,
+    RPC_TRANSACTION_REJECTED         = RPC_VERIFY_REJECTED,
+    RPC_TRANSACTION_ALREADY_IN_CHAIN = RPC_VERIFY_ALREADY_IN_CHAIN,
 
     // P2P client errors
     RPC_CLIENT_NOT_CONNECTED       = -9,  // Bitcoin is not connected

--- a/wallet/block.cpp
+++ b/wallet/block.cpp
@@ -622,7 +622,8 @@ bool CBlock::ConnectBlock(CTxDB& txdb, const CBlockIndexSmartPtr& pindex, bool f
                 }
             }
 
-            if (!tx.ConnectInputs(mapInputs, mapQueuedChanges, posThisTx, pindex, true, false, this)) {
+            if (tx.ConnectInputs(mapInputs, mapQueuedChanges, posThisTx, pindex, true, false, this)
+                    .isErr()) {
                 return false;
             }
         }

--- a/wallet/block.cpp
+++ b/wallet/block.cpp
@@ -1087,7 +1087,7 @@ bool CBlock::Reorganize(CTxDB& txdb, const CBlockIndexSmartPtr& pindexNew,
 
     // Resurrect memory transactions that were in the disconnected branch
     for (CTransaction& tx : vResurrect)
-        AcceptToMemoryPool(mempool, tx, NULL, &txdb);
+        AcceptToMemoryPool(mempool, tx, &txdb);
 
     // Delete redundant memory transactions that are in the connected branch
     for (CTransaction& tx : vDelete) {

--- a/wallet/block.cpp
+++ b/wallet/block.cpp
@@ -622,8 +622,7 @@ bool CBlock::ConnectBlock(CTxDB& txdb, const CBlockIndexSmartPtr& pindex, bool f
                 }
             }
 
-            if (!tx.ConnectInputs(txdb, mapInputs, mapQueuedChanges, posThisTx, pindex, true, false,
-                                  this)) {
+            if (!tx.ConnectInputs(mapInputs, mapQueuedChanges, posThisTx, pindex, true, false, this)) {
                 return false;
             }
         }

--- a/wallet/block.cpp
+++ b/wallet/block.cpp
@@ -1275,7 +1275,7 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig)
     for (unsigned i = 0; i < vtx.size(); i++) {
         const CTransaction& tx = vtx[i];
 
-        if (!tx.CheckTransaction(this))
+        if (tx.CheckTransaction(this).isErr())
             return DoS(tx.nDoS, error("CheckBlock() : CheckTransaction failed"));
 
         // ppcoin: check transaction timestamp

--- a/wallet/kernel.cpp
+++ b/wallet/kernel.cpp
@@ -353,7 +353,7 @@ bool CheckProofOfStake(const CTransaction& tx, unsigned int nBits, uint256& hash
                                                                                    // initial download
 
     // Verify signature
-    if (!VerifySignature(txPrev, tx, 0, false, false, 0))
+    if (VerifySignature(txPrev, tx, 0, false, false, 0).isErr())
         return tx.DoS(100, error("CheckProofOfStake() : VerifySignature failed on coinstake %s",
                                  tx.GetHash().ToString().c_str()));
 

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -405,7 +405,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInput
     if (pfMissingInputs)
         *pfMissingInputs = false;
 
-    if (!tx.CheckTransaction())
+    if (tx.CheckTransaction().isErr())
         return error("AcceptToMemoryPool : CheckTransaction failed");
 
     // Coinbase is only valid in a block, not as a loose transaction

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -542,13 +542,8 @@ Result<void, TxValidationState> AcceptToMemoryPool(CTxMemPool& pool, CTransactio
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-        if (!tx.ConnectInputs(mapInputs, mapUnused, CDiskTxPos(1, 1), boost::atomic_load(&pindexBest),
-                              false, false)) {
-            return Err(MakeInvalidTxState(TxValidationResult::TX_INPUT_CONNECT_FAILED,
-                                          "input-connect-error",
-                                          strprintf("AcceptToMemoryPool : ConnectInputs failed %s",
-                                                    hash.ToString().substr(0, 10).c_str())));
-        }
+        TRYV(tx.ConnectInputs(mapInputs, mapUnused, CDiskTxPos(1, 1), boost::atomic_load(&pindexBest),
+                              false, false));
 
         if (Params().PassedFirstValidNTP1Tx() &&
             Params().GetNetForks().isForkActivated(NetworkFork::NETFORK__3_TACHYON)) {

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -542,8 +542,8 @@ Result<void, TxValidationState> AcceptToMemoryPool(CTxMemPool& pool, CTransactio
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-        if (!tx.ConnectInputs(*txdb, mapInputs, mapUnused, CDiskTxPos(1, 1),
-                              boost::atomic_load(&pindexBest), false, false)) {
+        if (!tx.ConnectInputs(mapInputs, mapUnused, CDiskTxPos(1, 1), boost::atomic_load(&pindexBest),
+                              false, false)) {
             return Err(MakeInvalidTxState(TxValidationResult::TX_INPUT_CONNECT_FAILED,
                                           "input-connect-error",
                                           strprintf("AcceptToMemoryPool : ConnectInputs failed %s",

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -399,32 +399,33 @@ void AssertNTP1TokenNameIsNotAlreadyInMainChain(const NTP1Transaction& ntp1tx, C
     }
 }
 
-bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInputs, CTxDB* txdbPtr)
+Result<void, TxValidationState> AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, CTxDB* txdbPtr)
 {
     AssertLockHeld(cs_main);
-    if (pfMissingInputs)
-        *pfMissingInputs = false;
 
-    if (tx.CheckTransaction().isErr())
-        return error("AcceptToMemoryPool : CheckTransaction failed");
+    TRYV(tx.CheckTransaction());
 
     // Coinbase is only valid in a block, not as a loose transaction
-    if (tx.IsCoinBase())
-        return tx.DoS(100, error("AcceptToMemoryPool : coinbase as individual tx"));
+    if (tx.IsCoinBase()) {
+        tx.DoS(100, false);
+        return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "coinbase"));
+    }
 
     // ppcoin: coinstake is also only valid in a block, not as a loose transaction
-    if (tx.IsCoinStake())
-        return tx.DoS(100, error("AcceptToMemoryPool : coinstake as individual tx"));
+    if (tx.IsCoinStake()) {
+        tx.DoS(100, false);
+        return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "coinstake"));
+    }
 
     // Rather not work on nonstandard transactions (unless -testnet)
     string reason;
     if (Params().NetType() == NetworkType::Mainnet && !IsStandardTx(tx, reason))
-        return error("AcceptToMemoryPool : nonstandard transaction: %s", reason.c_str());
+        return Err(MakeInvalidTxState(TxValidationResult::TX_NOT_STANDARD, reason, "non-standard-tx"));
 
     // is it already in the memory pool?
     uint256 hash = tx.GetHash();
     if (pool.exists(hash))
-        return false;
+        return Err(MakeInvalidTxState(TxValidationResult::TX_CONFLICT, "txn-already-in-mempool"));
 
     // Check for conflicts with in-memory transactions
     CTransaction* ptxOld = NULL;
@@ -434,20 +435,24 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInput
             COutPoint outpoint = tx.vin[i].prevout;
             if (pool.mapNextTx.count(outpoint)) {
                 // Disable replacement feature for now
-                return false;
+                return Err(MakeInvalidTxState(TxValidationResult::TX_CONFLICT, "txn-mempool-conflict"));
 
                 // Allow replacing with a newer version of the same transaction
                 if (i != 0)
-                    return false;
+                    return Err(
+                        MakeInvalidTxState(TxValidationResult::TX_CONFLICT, "txn-mempool-conflict"));
                 ptxOld = pool.mapNextTx[outpoint].ptx;
                 if (IsFinalTx(*ptxOld))
-                    return false;
+                    return Err(
+                        MakeInvalidTxState(TxValidationResult::TX_CONFLICT, "txn-mempool-conflict"));
                 if (!tx.IsNewerThan(*ptxOld))
-                    return false;
+                    return Err(
+                        MakeInvalidTxState(TxValidationResult::TX_CONFLICT, "txn-mempool-conflict"));
                 for (unsigned int i = 0; i < tx.vin.size(); i++) {
                     COutPoint outpoint = tx.vin[i].prevout;
                     if (!pool.mapNextTx.count(outpoint) || pool.mapNextTx[outpoint].ptx != ptxOld)
-                        return false;
+                        return Err(
+                            MakeInvalidTxState(TxValidationResult::TX_CONFLICT, "txn-mempool-conflict"));
                 }
                 break;
             }
@@ -470,37 +475,44 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInput
 
         // do we already have it?
         if (txdb->ContainsTx(hash))
-            return false;
+            return Err(MakeInvalidTxState(TxValidationResult::TX_CONFLICT, "txn-already-known"));
 
         MapPrevTx                                                           mapInputs;
         map<uint256, CTxIndex>                                              mapUnused;
         map<uint256, std::vector<std::pair<CTransaction, NTP1Transaction>>> mapUnused2;
         bool                                                                fInvalid = false;
         if (!tx.FetchInputs(*txdb, mapUnused, false, false, mapInputs, fInvalid)) {
-            if (fInvalid)
-                return error("AcceptToMemoryPool : FetchInputs found invalid tx %s",
-                             hash.ToString().substr(0, 10).c_str());
-            if (pfMissingInputs)
-                *pfMissingInputs = true;
-            return false;
+            if (fInvalid) {
+                return Err(
+                    MakeInvalidTxState(TxValidationResult::TX_INVALID_INPUTS, "bad-txns-inputs-invalid",
+                                       strprintf("AcceptToMemoryPool : FetchInputs found invalid tx %s",
+                                                 hash.ToString().substr(0, 10).c_str())));
+            }
+            return Err(MakeInvalidTxState(TxValidationResult::TX_MISSING_INPUTS,
+                                          "bad-txns-inputs-missingorspent"));
         }
 
         // Check for non-standard pay-to-script-hash in inputs
-        if (!tx.AreInputsStandard(mapInputs) && Params().NetType() == NetworkType::Mainnet)
-            return error("AcceptToMemoryPool : nonstandard transaction input");
+        if (!tx.AreInputsStandard(mapInputs) && Params().NetType() == NetworkType::Mainnet) {
+            return Err(
+                MakeInvalidTxState(TxValidationResult::TX_NOT_STANDARD, "bad-txns-nonstandard-inputs"));
+        }
 
         // Note: if you modify this code to accept non-standard transactions, then
         // you should add code here to check that the transaction does a
         // reasonable number of ECDSA signature verifications.
 
-        int64_t      nFees = tx.GetValueIn(mapInputs) - tx.GetValueOut();
-        unsigned int nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
+        const int64_t      nFees = tx.GetValueIn(mapInputs) - tx.GetValueOut();
+        const unsigned int nSize = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 
         // Don't accept it if it can't get into a block
-        int64_t txMinFee = tx.GetMinFee(1000, GMF_RELAY, nSize);
-        if (nFees < txMinFee)
-            return error("AcceptToMemoryPool : not enough fees %s, %" PRId64 " < %" PRId64,
-                         hash.ToString().c_str(), nFees, txMinFee);
+        const int64_t txMinFee = tx.GetMinFee(1000, GMF_RELAY, nSize);
+        if (nFees < txMinFee) {
+            return Err(MakeInvalidTxState(TxValidationResult::TX_MEMPOOL_POLICY, "insufficient fee",
+                                          strprintf("AcceptToMemoryPool : not enough fees %s, %" PRId64
+                                                    " < %" PRId64,
+                                                    hash.ToString().c_str(), nFees, txMinFee)));
+        }
 
         // Continuously rate-limit free transactions
         // This mitigates 'penny-flooding' -- sending thousands of free transactions just to
@@ -519,7 +531,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInput
                 // -limitfreerelay unit is thousand-bytes-per-minute
                 // At default rate it would take over a month to fill 1GB
                 if (dFreeCount > GetArg("-limitfreerelay", 15) * 10 * 1000 && !IsFromMe(tx))
-                    return error("AcceptToMemoryPool : free transaction rejected by rate limiter");
+                    return Err(MakeInvalidTxState(TxValidationResult::TX_MEMPOOL_POLICY,
+                                                  "fee-rejected-by-rate-limiter"));
+
                 if (fDebug)
                     printf("Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount + nSize);
                 dFreeCount += nSize;
@@ -530,8 +544,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInput
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
         if (!tx.ConnectInputs(*txdb, mapInputs, mapUnused, CDiskTxPos(1, 1),
                               boost::atomic_load(&pindexBest), false, false)) {
-            return error("AcceptToMemoryPool : ConnectInputs failed %s",
-                         hash.ToString().substr(0, 10).c_str());
+            return Err(MakeInvalidTxState(TxValidationResult::TX_INPUT_CONNECT_FAILED,
+                                          "input-connect-error",
+                                          strprintf("AcceptToMemoryPool : ConnectInputs failed %s",
+                                                    hash.ToString().substr(0, 10).c_str())));
         }
 
         if (Params().PassedFirstValidNTP1Tx() &&
@@ -550,13 +566,16 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInput
                        "pool; an exception was "
                        "thrown: %s\n",
                        ex.what());
-                return false;
+                // TX_NTP1_ERROR
+                return Err(MakeInvalidTxState(
+                    TxValidationResult::TX_NTP1_ERROR, "ntp1-error",
+                    strprintf(
+                        "AcceptToMemoryPool: An invalid NTP1 transaction was submitted to the memory "
+                        "pool; an exception was "
+                        "thrown: %s\n",
+                        ex.what())));
             } catch (...) {
-                printf("AcceptToMemoryPool: An invalid NTP1 transaction was submitted to the memory "
-                       "pool; an unknown "
-                       "exception was "
-                       "thrown.");
-                return false;
+                return Err(MakeInvalidTxState(TxValidationResult::TX_NTP1_ERROR, "ntp1-error-unknown"));
             }
         }
     }
@@ -580,7 +599,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInput
     printf("AcceptToMemoryPool : accepted %s (poolsz %" PRIszu ")\n",
            hash.ToString().substr(0, 10).c_str(), pool.mapTx.size());
 
-    return true;
+    return Ok();
 }
 
 // Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock
@@ -2077,8 +2096,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         CInv inv(MSG_TX, tx.GetHash());
         pfrom->AddInventoryKnown(inv);
 
-        bool fMissingInputs = false;
-        if (AcceptToMemoryPool(mempool, tx, &fMissingInputs)) {
+        const Result<void, TxValidationState> mempoolRes = AcceptToMemoryPool(mempool, tx);
+        if (mempoolRes.isOk()) {
             SyncWithWallets(tx, nullptr);
             RelayTransaction(tx);
             mapAlreadyAskedFor.erase(inv);
@@ -2090,18 +2109,20 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
                 uint256 hashPrev = vWorkQueue[i];
                 for (set<uint256>::iterator mi = mapOrphanTransactionsByPrev[hashPrev].begin();
                      mi != mapOrphanTransactionsByPrev[hashPrev].end(); ++mi) {
-                    const uint256& orphanTxHash    = *mi;
-                    CTransaction&  orphanTx        = mapOrphanTransactions[orphanTxHash];
-                    bool           fMissingInputs2 = false;
+                    const uint256& orphanTxHash = *mi;
+                    CTransaction&  orphanTx     = mapOrphanTransactions[orphanTxHash];
 
-                    if (AcceptToMemoryPool(mempool, orphanTx, &fMissingInputs2)) {
+                    const Result<void, TxValidationState> mempoolOrphanRes =
+                        AcceptToMemoryPool(mempool, orphanTx);
+                    if (mempoolOrphanRes.isOk()) {
                         printf("   accepted orphan tx %s\n", orphanTxHash.ToString().c_str());
                         SyncWithWallets(tx, nullptr);
                         RelayTransaction(orphanTx);
                         mapAlreadyAskedFor.erase(CInv(MSG_TX, orphanTxHash));
                         vWorkQueue.push_back(orphanTxHash);
                         vEraseQueue.push_back(orphanTxHash);
-                    } else if (!fMissingInputs2) {
+                    } else if (mempoolRes.unwrapErr().GetResult() !=
+                               TxValidationResult::TX_MISSING_INPUTS) {
                         // invalid orphan
                         vEraseQueue.push_back(orphanTxHash);
                         printf("   removed invalid orphan tx %s\n", orphanTxHash.ToString().c_str());
@@ -2111,7 +2132,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
 
             for (uint256 hash : vEraseQueue)
                 EraseOrphanTx(hash);
-        } else if (fMissingInputs) {
+        } else if (mempoolRes.unwrapErr().GetResult() == TxValidationResult::TX_MISSING_INPUTS) {
             AddOrphanTx(tx);
 
             // DoS prevention: do not allow mapOrphanTransactions to grow unbounded

--- a/wallet/main.h
+++ b/wallet/main.h
@@ -165,8 +165,8 @@ bool IsTxInMainChain(const uint256& txHash);
 int64_t GetTxBlockHeight(const uint256& txHash);
 
 /** (try to) add transaction to memory pool **/
-bool AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx, bool* pfMissingInputs,
-                        CTxDB* txdbPtr = nullptr);
+Result<void, TxValidationState> AcceptToMemoryPool(CTxMemPool& pool, CTransaction& tx,
+                                                   CTxDB* txdbPtr = nullptr);
 
 bool EnableEnforceUniqueTokenSymbols();
 

--- a/wallet/makefile.unix
+++ b/wallet/makefile.unix
@@ -244,7 +244,9 @@ OBJS= \
     obj/wallet_ismine.o                       \
     obj/stakemaker.o                          \
     obj/work.o                                \
-    obj/addressbook.o
+    obj/addressbook.o                         \
+    obj/script_error.o                        \
+    obj/validation.o
 
 ifdef NEBLIO_REST
     OBJS += obj/nebliorest.o

--- a/wallet/merkletx.cpp
+++ b/wallet/merkletx.cpp
@@ -42,7 +42,10 @@ int CMerkleTx::GetBlocksToMaturity() const
     return std::max(0, (nCbM + 1) - GetDepthInMainChain());
 }
 
-bool CMerkleTx::AcceptToMemoryPool() { return ::AcceptToMemoryPool(mempool, *this, NULL); }
+Result<void, TxValidationState> CMerkleTx::AcceptToMemoryPool()
+{
+    return ::AcceptToMemoryPool(mempool, *this);
+}
 
 bool CMerkleTx::hashUnset() const { return (hashBlock.IsNull() || hashBlock == ABANDON_HASH); }
 

--- a/wallet/merkletx.h
+++ b/wallet/merkletx.h
@@ -54,11 +54,11 @@ public:
         const CBlockIndex* pindexRet = nullptr;
         return GetDepthInMainChain(pindexRet) > 0;
     }
-    int  GetBlocksToMaturity() const;
-    bool AcceptToMemoryPool();
-    bool hashUnset() const;
-    bool isAbandoned() const;
-    void setAbandoned();
+    int                             GetBlocksToMaturity() const;
+    Result<void, TxValidationState> AcceptToMemoryPool();
+    bool                            hashUnset() const;
+    bool                            isAbandoned() const;
+    void                            setAbandoned();
 };
 
 #endif // MERKLETX_H

--- a/wallet/miner.cpp
+++ b/wallet/miner.cpp
@@ -376,7 +376,8 @@ std::unique_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int
                 continue;
             }
 
-            if (!tx.ConnectInputs(mapInputs, mapTestPoolTmp, CDiskTxPos(1, 1), pindexPrev, false, true))
+            if (tx.ConnectInputs(mapInputs, mapTestPoolTmp, CDiskTxPos(1, 1), pindexPrev, false, true)
+                    .isErr())
                 continue;
 
             mapTestPoolTmp[tx.GetHash()] = CTxIndex(CDiskTxPos(1, 1), tx.vout.size());

--- a/wallet/miner.cpp
+++ b/wallet/miner.cpp
@@ -376,8 +376,7 @@ std::unique_ptr<CBlock> CreateNewBlock(CWallet* pwallet, bool fProofOfStake, int
                 continue;
             }
 
-            if (!tx.ConnectInputs(txdb, mapInputs, mapTestPoolTmp, CDiskTxPos(1, 1), pindexPrev, false,
-                                  true))
+            if (!tx.ConnectInputs(mapInputs, mapTestPoolTmp, CDiskTxPos(1, 1), pindexPrev, false, true))
                 continue;
 
             mapTestPoolTmp[tx.GetHash()] = CTxIndex(CDiskTxPos(1, 1), tx.vout.size());

--- a/wallet/result.h
+++ b/wallet/result.h
@@ -803,7 +803,7 @@ struct Constructor<void, E>
 
 } // namespace details
 
-namespace concepts {
+namespace conceptsNS {
 
 template <typename T, typename = void>
 struct EqualityComparable : std::false_type
@@ -818,7 +818,7 @@ struct EqualityComparable<
 {
 };
 
-} // namespace concepts
+} // namespace conceptsNS
 
 template <typename T, typename E>
 struct Result
@@ -960,9 +960,9 @@ private:
 template <typename T, typename E>
 bool operator==(const Result<T, E>& lhs, const Result<T, E>& rhs)
 {
-    static_assert(concepts ::EqualityComparable<T>::value,
+    static_assert(conceptsNS::EqualityComparable<T>::value,
                   "T must be EqualityComparable for Result to be comparable");
-    static_assert(concepts ::EqualityComparable<E>::value,
+    static_assert(conceptsNS::EqualityComparable<E>::value,
                   "E must be EqualityComparable for Result to be comparable");
 
     if (lhs.isOk() && rhs.isOk()) {
@@ -977,7 +977,7 @@ bool operator==(const Result<T, E>& lhs, const Result<T, E>& rhs)
 template <typename T, typename E>
 bool operator==(const Result<T, E>& lhs, types::Ok<T> ok)
 {
-    static_assert(concepts ::EqualityComparable<T>::value,
+    static_assert(conceptsNS ::EqualityComparable<T>::value,
                   "T must be EqualityComparable for Result to be comparable");
 
     if (!lhs.isOk())
@@ -995,7 +995,7 @@ bool operator==(const Result<void, E>& lhs, types::Ok<void>)
 template <typename T, typename E>
 bool operator==(const Result<T, E>& lhs, types::Err<E> err)
 {
-    static_assert(concepts ::EqualityComparable<E>::value,
+    static_assert(conceptsNS ::EqualityComparable<E>::value,
                   "E must be EqualityComparable for Result to be comparable");
     if (!lhs.isErr())
         return false;
@@ -1012,4 +1012,13 @@ bool operator==(const Result<T, E>& lhs, types::Err<E> err)
         }                                                                                               \
         typedef details::ResultOkType<decltype(res)>::type T;                                           \
         res.storage().get<T>();                                                                         \
+    })
+
+#define TRYV(...)                                                                                       \
+    ({                                                                                                  \
+        auto res = __VA_ARGS__;                                                                         \
+        if (!res.isOk()) {                                                                              \
+            typedef details::ResultErrType<decltype(res)>::type E;                                      \
+            return types::Err<E>(res.storage().get<E>());                                               \
+        }                                                                                               \
     })

--- a/wallet/result.h
+++ b/wallet/result.h
@@ -1,0 +1,1015 @@
+/*
+   Mathieu Stefani, 03 mai 2016
+
+   This header provides a Result type that can be used to replace exceptions in code
+   that has to handle error.
+
+   Result<T, E> can be used to return and propagate an error to the caller. Result<T, E> is an algebraic
+   data type that can either Ok(T) to represent success or Err(E) to represent an error.
+*/
+
+#pragma once
+
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+namespace types {
+template <typename T>
+struct Ok
+{
+    Ok(const T& val) : val(val) {}
+    Ok(T&& val) : val(std::move(val)) {}
+
+    T val;
+};
+
+template <>
+struct Ok<void>
+{
+};
+
+template <typename E>
+struct Err
+{
+    Err(const E& val) : val(val) {}
+    Err(E&& val) : val(std::move(val)) {}
+
+    E val;
+};
+} // namespace types
+
+template <typename T, typename CleanT = typename std::decay<T>::type>
+types::Ok<CleanT> Ok(T&& val)
+{
+    return types::Ok<CleanT>(std::forward<T>(val));
+}
+
+inline types::Ok<void> Ok() { return types::Ok<void>(); }
+
+template <typename E, typename CleanE = typename std::decay<E>::type>
+types::Err<CleanE> Err(E&& val)
+{
+    return types::Err<CleanE>(std::forward<E>(val));
+}
+
+template <typename T, typename E>
+struct Result;
+
+namespace details {
+
+template <typename...>
+struct void_t
+{
+    typedef void type;
+};
+
+namespace impl {
+template <typename Func>
+struct result_of;
+
+template <typename Ret, typename Cls, typename... Args>
+struct result_of<Ret (Cls::*)(Args...)> : public result_of<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename... Args>
+struct result_of<Ret(Args...)>
+{
+    typedef Ret type;
+};
+} // namespace impl
+
+template <typename Func>
+struct result_of : public impl::result_of<decltype(&Func::operator())>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct result_of<Ret (Cls::*)(Args...) const>
+{
+    typedef Ret type;
+};
+
+template <typename Ret, typename... Args>
+struct result_of<Ret (*)(Args...)>
+{
+    typedef Ret type;
+};
+
+template <typename R>
+struct ResultOkType
+{
+    typedef typename std::decay<R>::type type;
+};
+
+template <typename T, typename E>
+struct ResultOkType<Result<T, E>>
+{
+    typedef T type;
+};
+
+template <typename R>
+struct ResultErrType
+{
+    typedef R type;
+};
+
+template <typename T, typename E>
+struct ResultErrType<Result<T, E>>
+{
+    typedef typename std::remove_reference<E>::type type;
+};
+
+template <typename R>
+struct IsResult : public std::false_type
+{
+};
+template <typename T, typename E>
+struct IsResult<Result<T, E>> : public std::true_type
+{
+};
+
+namespace ok {
+
+namespace impl {
+
+template <typename T>
+struct Map;
+
+template <typename Ret, typename Cls, typename Arg>
+struct Map<Ret (Cls::*)(Arg) const> : public Map<Ret(Arg)>
+{
+};
+
+template <typename Ret, typename Cls, typename Arg>
+struct Map<Ret (Cls::*)(Arg)> : public Map<Ret(Arg)>
+{
+};
+
+// General implementation
+template <typename Ret, typename Arg>
+struct Map<Ret(Arg)>
+{
+
+    static_assert(!IsResult<Ret>::value,
+                  "Can not map a callback returning a Result, use andThen instead");
+
+    template <typename T, typename E, typename Func>
+    static Result<Ret, E> map(const Result<T, E>& result, Func func)
+    {
+
+        static_assert(std::is_same<T, Arg>::value || std::is_convertible<T, Arg>::value,
+                      "Incompatible types detected");
+
+        if (result.isOk()) {
+            auto res = func(result.storage().template get<T>());
+            return types::Ok<Ret>(std::move(res));
+        }
+
+        return types::Err<E>(result.storage().template get<E>());
+    }
+};
+
+// Specialization for callback returning void
+template <typename Arg>
+struct Map<void(Arg)>
+{
+
+    template <typename T, typename E, typename Func>
+    static Result<void, E> map(const Result<T, E>& result, Func func)
+    {
+
+        if (result.isOk()) {
+            func(result.storage().template get<T>());
+            return types::Ok<void>();
+        }
+
+        return types::Err<E>(result.storage().template get<E>());
+    }
+};
+
+// Specialization for a void Result
+template <typename Ret>
+struct Map<Ret(void)>
+{
+
+    template <typename T, typename E, typename Func>
+    static Result<Ret, E> map(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<T, void>::value, "Can not map a void callback on a non-void Result");
+
+        if (result.isOk()) {
+            auto ret = func();
+            return types::Ok<Ret>(std::move(ret));
+        }
+
+        return types::Err<E>(result.storage().template get<E>());
+    }
+};
+
+// Specialization for callback returning void on a void Result
+template <>
+struct Map<void(void)>
+{
+
+    template <typename T, typename E, typename Func>
+    static Result<void, E> map(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<T, void>::value, "Can not map a void callback on a non-void Result");
+
+        if (result.isOk()) {
+            func();
+            return types::Ok<void>();
+        }
+
+        return types::Err<E>(result.storage().template get<E>());
+    }
+};
+
+// General specialization for a callback returning a Result
+template <typename U, typename E, typename Arg>
+struct Map<Result<U, E>(Arg)>
+{
+
+    template <typename T, typename Func>
+    static Result<U, E> map(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<T, Arg>::value || std::is_convertible<T, Arg>::value,
+                      "Incompatible types detected");
+
+        if (result.isOk()) {
+            auto res = func(result.storage().template get<T>());
+            return res;
+        }
+
+        return types::Err<E>(result.storage().template get<E>());
+    }
+};
+
+// Specialization for a void callback returning a Result
+template <typename U, typename E>
+struct Map<Result<U, E>(void)>
+{
+
+    template <typename T, typename Func>
+    static Result<U, E> map(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<T, void>::value, "Can not call a void-callback on a non-void Result");
+
+        if (result.isOk()) {
+            auto res = func();
+            return res;
+        }
+
+        return types::Err<E>(result.storage().template get<E>());
+    }
+};
+
+} // namespace impl
+
+template <typename Func>
+struct Map : public impl::Map<decltype(&Func::operator())>
+{
+};
+
+template <typename Ret, typename... Args>
+struct Map<Ret (*)(Args...)> : public impl::Map<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Map<Ret (Cls::*)(Args...)> : public impl::Map<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Map<Ret (Cls::*)(Args...) const> : public impl::Map<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename... Args>
+struct Map<std::function<Ret(Args...)>> : public impl::Map<Ret(Args...)>
+{
+};
+
+} // namespace ok
+
+namespace err {
+
+namespace impl {
+
+template <typename T>
+struct Map;
+
+template <typename Ret, typename Cls, typename Arg>
+struct Map<Ret (Cls::*)(Arg) const>
+{
+
+    static_assert(!IsResult<Ret>::value,
+                  "Can not map a callback returning a Result, use orElse instead");
+
+    template <typename T, typename E, typename Func>
+    static Result<T, Ret> map(const Result<T, E>& result, Func func)
+    {
+        if (result.isErr()) {
+            auto res = func(result.storage().template get<E>());
+            return types::Err<Ret>(res);
+        }
+
+        return types::Ok<T>(result.storage().template get<T>());
+    }
+
+    template <typename E, typename Func>
+    static Result<void, Ret> map(const Result<void, E>& result, Func func)
+    {
+        if (result.isErr()) {
+            auto res = func(result.storage().template get<E>());
+            return types::Err<Ret>(res);
+        }
+
+        return types::Ok<void>();
+    }
+};
+
+} // namespace impl
+
+template <typename Func>
+struct Map : public impl::Map<decltype(&Func::operator())>
+{
+};
+
+} // namespace err
+
+namespace And {
+
+namespace impl {
+
+template <typename Func>
+struct Then;
+
+template <typename Ret, typename... Args>
+struct Then<Ret (*)(Args...)> : public Then<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Then<Ret (Cls::*)(Args...)> : public Then<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Then<Ret (Cls::*)(Args...) const> : public Then<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Arg>
+struct Then<Ret(Arg)>
+{
+    static_assert(std::is_same<Ret, void>::value,
+                  "then() should not return anything, use map() instead");
+
+    template <typename T, typename E, typename Func>
+    static Result<T, E> then(const Result<T, E>& result, Func func)
+    {
+        if (result.isOk()) {
+            func(result.storage().template get<T>());
+        }
+        return result;
+    }
+};
+
+template <typename Ret>
+struct Then<Ret(void)>
+{
+    static_assert(std::is_same<Ret, void>::value,
+                  "then() should not return anything, use map() instead");
+
+    template <typename T, typename E, typename Func>
+    static Result<T, E> then(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<T, void>::value, "Can not call a void-callback on a non-void Result");
+
+        if (result.isOk()) {
+            func();
+        }
+
+        return result;
+    }
+};
+
+} // namespace impl
+
+template <typename Func>
+struct Then : public impl::Then<decltype(&Func::operator())>
+{
+};
+
+template <typename Ret, typename... Args>
+struct Then<Ret (*)(Args...)> : public impl::Then<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Then<Ret (Cls::*)(Args...)> : public impl::Then<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Then<Ret (Cls::*)(Args...) const> : public impl::Then<Ret(Args...)>
+{
+};
+
+} // namespace And
+
+namespace Or {
+
+namespace impl {
+
+template <typename Func>
+struct Else;
+
+template <typename Ret, typename... Args>
+struct Else<Ret (*)(Args...)> : public Else<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Else<Ret (Cls::*)(Args...)> : public Else<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Else<Ret (Cls::*)(Args...) const> : public Else<Ret(Args...)>
+{
+};
+
+template <typename T, typename F, typename Arg>
+struct Else<Result<T, F>(Arg)>
+{
+
+    template <typename E, typename Func>
+    static Result<T, F> orElse(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<E, Arg>::value || std::is_convertible<E, Arg>::value,
+                      "Incompatible types detected");
+
+        if (result.isErr()) {
+            auto res = func(result.storage().template get<E>());
+            return res;
+        }
+
+        return types::Ok<T>(result.storage().template get<T>());
+    }
+
+    template <typename E, typename Func>
+    static Result<void, F> orElse(const Result<void, E>& result, Func func)
+    {
+        if (result.isErr()) {
+            auto res = func(result.storage().template get<E>());
+            return res;
+        }
+
+        return types::Ok<void>();
+    }
+};
+
+template <typename T, typename F>
+struct Else<Result<T, F>(void)>
+{
+
+    template <typename E, typename Func>
+    static Result<T, F> orElse(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<T, void>::value, "Can not call a void-callback on a non-void Result");
+
+        if (result.isErr()) {
+            auto res = func();
+            return res;
+        }
+
+        return types::Ok<T>(result.storage().template get<T>());
+    }
+
+    template <typename E, typename Func>
+    static Result<void, F> orElse(const Result<void, E>& result, Func func)
+    {
+        if (result.isErr()) {
+            auto res = func();
+            return res;
+        }
+
+        return types::Ok<void>();
+    }
+};
+
+} // namespace impl
+
+template <typename Func>
+struct Else : public impl::Else<decltype(&Func::operator())>
+{
+};
+
+template <typename Ret, typename... Args>
+struct Else<Ret (*)(Args...)> : public impl::Else<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Else<Ret (Cls::*)(Args...)> : public impl::Else<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Else<Ret (Cls::*)(Args...) const> : public impl::Else<Ret(Args...)>
+{
+};
+
+} // namespace Or
+
+namespace Other {
+
+namespace impl {
+
+template <typename Func>
+struct Wise;
+
+template <typename Ret, typename... Args>
+struct Wise<Ret (*)(Args...)> : public Wise<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Wise<Ret (Cls::*)(Args...)> : public Wise<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Wise<Ret (Cls::*)(Args...) const> : public Wise<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Arg>
+struct Wise<Ret(Arg)>
+{
+
+    template <typename T, typename E, typename Func>
+    static Result<T, E> otherwise(const Result<T, E>& result, Func func)
+    {
+        static_assert(std::is_same<E, Arg>::value || std::is_convertible<E, Arg>::value,
+                      "Incompatible types detected");
+
+        static_assert(std::is_same<Ret, void>::value,
+                      "callback should not return anything, use mapError() for that");
+
+        if (result.isErr()) {
+            func(result.storage().template get<E>());
+        }
+        return result;
+    }
+};
+
+} // namespace impl
+
+template <typename Func>
+struct Wise : public impl::Wise<decltype(&Func::operator())>
+{
+};
+
+template <typename Ret, typename... Args>
+struct Wise<Ret (*)(Args...)> : public impl::Wise<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Wise<Ret (Cls::*)(Args...)> : public impl::Wise<Ret(Args...)>
+{
+};
+
+template <typename Ret, typename Cls, typename... Args>
+struct Wise<Ret (Cls::*)(Args...) const> : public impl::Wise<Ret(Args...)>
+{
+};
+
+} // namespace Other
+
+template <typename T, typename E, typename Func,
+          typename Ret =
+              Result<typename details::ResultOkType<typename details::result_of<Func>::type>::type, E>>
+Ret map(const Result<T, E>& result, Func func)
+{
+    return ok::Map<Func>::map(result, func);
+}
+
+template <typename T, typename E, typename Func,
+          typename Ret =
+              Result<T, typename details::ResultErrType<typename details::result_of<Func>::type>::type>>
+Ret mapError(const Result<T, E>& result, Func func)
+{
+    return err::Map<Func>::map(result, func);
+}
+
+template <typename T, typename E, typename Func>
+Result<T, E> then(const Result<T, E>& result, Func func)
+{
+    return And::Then<Func>::then(result, func);
+}
+
+template <typename T, typename E, typename Func>
+Result<T, E> otherwise(const Result<T, E>& result, Func func)
+{
+    return Other::Wise<Func>::otherwise(result, func);
+}
+
+template <typename T, typename E, typename Func,
+          typename Ret =
+              Result<T, typename details::ResultErrType<typename details::result_of<Func>::type>::type>>
+Ret orElse(const Result<T, E>& result, Func func)
+{
+    return Or::Else<Func>::orElse(result, func);
+}
+
+struct ok_tag
+{
+};
+struct err_tag
+{
+};
+
+template <typename T, typename E>
+struct Storage
+{
+    static constexpr size_t Size  = sizeof(T) > sizeof(E) ? sizeof(T) : sizeof(E);
+    static constexpr size_t Align = sizeof(T) > sizeof(E) ? alignof(T) : alignof(E);
+
+    typedef typename std::aligned_storage<Size, Align>::type type;
+
+    Storage() : initialized_(false) {}
+
+    void construct(types::Ok<T>&& ok)
+    {
+        new (&storage_) T(std::move(ok.val));
+        initialized_ = true;
+    }
+    void construct(const types::Ok<T>& ok)
+    {
+        new (&storage_) T(ok.val);
+        initialized_ = true;
+    }
+    void construct(types::Err<E>&& err)
+    {
+        new (&storage_) E(err.val);
+        initialized_ = true;
+    }
+    void construct(const types::Err<E>& err)
+    {
+        new (&storage_) E(err.val);
+        initialized_ = true;
+    }
+
+    template <typename U>
+    void rawConstruct(U&& val)
+    {
+        typedef typename std::decay<U>::type CleanU;
+
+        new (&storage_) CleanU(std::forward<U>(val));
+        initialized_ = true;
+    }
+
+    template <typename U>
+    const U& get() const
+    {
+        return *reinterpret_cast<const U*>(&storage_);
+    }
+
+    template <typename U>
+    U& get()
+    {
+        return *reinterpret_cast<U*>(&storage_);
+    }
+
+    void destroy(ok_tag)
+    {
+        if (initialized_) {
+            get<T>().~T();
+            initialized_ = false;
+        }
+    }
+
+    void destroy(err_tag)
+    {
+        if (initialized_) {
+            get<E>().~E();
+            initialized_ = false;
+        }
+    }
+
+    type storage_;
+    bool initialized_;
+};
+
+template <typename E>
+struct Storage<void, E>
+{
+    typedef typename std::aligned_storage<sizeof(E), alignof(E)>::type type;
+
+    void construct(types::Ok<void>) { initialized_ = true; }
+
+    void construct(types::Err<E> err)
+    {
+        new (&storage_) E(err.val);
+        initialized_ = true;
+    }
+
+    template <typename U>
+    void rawConstruct(U&& val)
+    {
+        typedef typename std::decay<U>::type CleanU;
+
+        new (&storage_) CleanU(std::forward<U>(val));
+        initialized_ = true;
+    }
+
+    void destroy(ok_tag) { initialized_ = false; }
+    void destroy(err_tag)
+    {
+        if (initialized_) {
+            get<E>().~E();
+            initialized_ = false;
+        }
+    }
+
+    template <typename U>
+    const U& get() const
+    {
+        return *reinterpret_cast<const U*>(&storage_);
+    }
+
+    template <typename U>
+    U& get()
+    {
+        return *reinterpret_cast<U*>(&storage_);
+    }
+
+    type storage_;
+    bool initialized_;
+};
+
+template <typename T, typename E>
+struct Constructor
+{
+
+    static void move(Storage<T, E>&& src, Storage<T, E>& dst, ok_tag)
+    {
+        dst.rawConstruct(std::move(src.template get<T>()));
+        src.destroy(ok_tag());
+    }
+
+    static void copy(const Storage<T, E>& src, Storage<T, E>& dst, ok_tag)
+    {
+        dst.rawConstruct(src.template get<T>());
+    }
+
+    static void move(Storage<T, E>&& src, Storage<T, E>& dst, err_tag)
+    {
+        dst.rawConstruct(std::move(src.template get<E>()));
+        src.destroy(err_tag());
+    }
+
+    static void copy(const Storage<T, E>& src, Storage<T, E>& dst, err_tag)
+    {
+        dst.rawConstruct(src.template get<E>());
+    }
+};
+
+template <typename E>
+struct Constructor<void, E>
+{
+    static void move(Storage<void, E>&& /*src*/, Storage<void, E>& /*dst*/, ok_tag) {}
+
+    static void copy(const Storage<void, E>& /*src*/, Storage<void, E>& /*dst*/, ok_tag) {}
+
+    static void move(Storage<void, E>&& src, Storage<void, E>& dst, err_tag)
+    {
+        dst.rawConstruct(std::move(src.template get<E>()));
+        src.destroy(err_tag());
+    }
+
+    static void copy(const Storage<void, E>& src, Storage<void, E>& dst, err_tag)
+    {
+        dst.rawConstruct(src.template get<E>());
+    }
+};
+
+} // namespace details
+
+namespace concepts {
+
+template <typename T, typename = void>
+struct EqualityComparable : std::false_type
+{
+};
+
+template <typename T>
+struct EqualityComparable<
+    T, typename std::enable_if<
+           true, typename details::void_t<decltype(std::declval<T>() == std::declval<T>())>::type>::type>
+    : std::true_type
+{
+};
+
+} // namespace concepts
+
+template <typename T, typename E>
+struct Result
+{
+
+    static_assert(!std::is_same<E, void>::value, "void error type is not allowed");
+
+    typedef details::Storage<T, E> storage_type;
+
+    Result(types::Ok<T>&& ok) : ok_(true) { storage_.construct(std::move(ok)); }
+
+    Result(const types::Ok<T>& ok) : ok_(true) { storage_.construct(ok); }
+
+    Result(types::Err<E>&& err) : ok_(false) { storage_.construct(std::move(err)); }
+
+    Result(const types::Err<E>& err) : ok_(false) { storage_.construct(err); }
+
+    Result(Result&& other)
+    {
+        if (other.isOk()) {
+            details::Constructor<T, E>::move(std::move(other.storage_), storage_, details::ok_tag());
+            ok_ = true;
+        } else {
+            details::Constructor<T, E>::move(std::move(other.storage_), storage_, details::err_tag());
+            ok_ = false;
+        }
+    }
+
+    Result(const Result& other)
+    {
+        if (other.isOk()) {
+            details::Constructor<T, E>::copy(other.storage_, storage_, details::ok_tag());
+            ok_ = true;
+        } else {
+            details::Constructor<T, E>::copy(other.storage_, storage_, details::err_tag());
+            ok_ = false;
+        }
+    }
+
+    ~Result()
+    {
+        if (ok_)
+            storage_.destroy(details::ok_tag());
+        else
+            storage_.destroy(details::err_tag());
+    }
+
+    bool isOk() const { return ok_; }
+
+    bool isErr() const { return !ok_; }
+
+    T expect(const char* str) const
+    {
+        if (!isOk()) {
+            std::fprintf(stderr, "%s\n", str);
+            std::terminate();
+        }
+        return expect_impl(std::is_same<T, void>());
+    }
+
+    template <typename Func,
+              typename Ret = Result<
+                  typename details::ResultOkType<typename details::result_of<Func>::type>::type, E>>
+    Ret map(Func func) const
+    {
+        return details::map(*this, func);
+    }
+
+    template <typename Func,
+              typename Ret = Result<
+                  T, typename details::ResultErrType<typename details::result_of<Func>::type>::type>>
+    Ret mapError(Func func) const
+    {
+        return details::mapError(*this, func);
+    }
+
+    template <typename Func>
+    Result<T, E> then(Func func) const
+    {
+        return details::then(*this, func);
+    }
+
+    template <typename Func>
+    Result<T, E> otherwise(Func func) const
+    {
+        return details::otherwise(*this, func);
+    }
+
+    template <typename Func,
+              typename Ret = Result<
+                  T, typename details::ResultErrType<typename details::result_of<Func>::type>::type>>
+    Ret orElse(Func func) const
+    {
+        return details::orElse(*this, func);
+    }
+
+    storage_type& storage() { return storage_; }
+
+    const storage_type& storage() const { return storage_; }
+
+    template <typename U = T>
+    typename std::enable_if<!std::is_same<U, void>::value, U>::type unwrapOr(const U& defaultValue) const
+    {
+        if (isOk()) {
+            return storage().template get<U>();
+        }
+        return defaultValue;
+    }
+
+    template <typename U = T>
+    typename std::enable_if<!std::is_same<U, void>::value, U>::type unwrap() const
+    {
+        if (isOk()) {
+            return storage().template get<U>();
+        }
+
+        std::fprintf(stderr, "Attempting to unwrap an error Result\n");
+        std::terminate();
+    }
+
+    E unwrapErr() const
+    {
+        if (isErr()) {
+            return storage().template get<E>();
+        }
+
+        std::fprintf(stderr, "Attempting to unwrapErr an ok Result\n");
+        std::terminate();
+    }
+
+private:
+    T expect_impl(std::true_type) const {}
+    T expect_impl(std::false_type) const { return storage_.template get<T>(); }
+
+    bool         ok_;
+    storage_type storage_;
+};
+
+template <typename T, typename E>
+bool operator==(const Result<T, E>& lhs, const Result<T, E>& rhs)
+{
+    static_assert(concepts ::EqualityComparable<T>::value,
+                  "T must be EqualityComparable for Result to be comparable");
+    static_assert(concepts ::EqualityComparable<E>::value,
+                  "E must be EqualityComparable for Result to be comparable");
+
+    if (lhs.isOk() && rhs.isOk()) {
+        return lhs.storage().template get<T>() == rhs.storage().template get<T>();
+    }
+    if (lhs.isErr() && rhs.isErr()) {
+        return lhs.storage().template get<E>() == rhs.storage().template get<E>();
+    }
+    return false;
+}
+
+template <typename T, typename E>
+bool operator==(const Result<T, E>& lhs, types::Ok<T> ok)
+{
+    static_assert(concepts ::EqualityComparable<T>::value,
+                  "T must be EqualityComparable for Result to be comparable");
+
+    if (!lhs.isOk())
+        return false;
+
+    return lhs.storage().template get<T>() == ok.val;
+}
+
+template <typename E>
+bool operator==(const Result<void, E>& lhs, types::Ok<void>)
+{
+    return lhs.isOk();
+}
+
+template <typename T, typename E>
+bool operator==(const Result<T, E>& lhs, types::Err<E> err)
+{
+    static_assert(concepts ::EqualityComparable<E>::value,
+                  "E must be EqualityComparable for Result to be comparable");
+    if (!lhs.isErr())
+        return false;
+
+    return lhs.storage().template get<E>() == err.val;
+}
+
+#define TRY(...)                                                                                        \
+    ({                                                                                                  \
+        auto res = __VA_ARGS__;                                                                         \
+        if (!res.isOk()) {                                                                              \
+            typedef details::ResultErrType<decltype(res)>::type E;                                      \
+            return types::Err<E>(res.storage().get<E>());                                               \
+        }                                                                                               \
+        typedef details::ResultOkType<decltype(res)>::type T;                                           \
+        res.storage().get<T>();                                                                         \
+    })

--- a/wallet/rpcrawtransaction.cpp
+++ b/wallet/rpcrawtransaction.cpp
@@ -783,7 +783,7 @@ Value signrawtransaction(const Array& params, bool fHelp)
         }
         const CScript& prevPubKey = mapPrevOut[txin.prevout];
 
-        if (!VerifyScript(txin.scriptSig, prevPubKey, mergedTx, i, true, true, 0))
+        if (VerifyScript(txin.scriptSig, prevPubKey, mergedTx, i, true, true, 0).isErr())
             fComplete = false;
     }
 

--- a/wallet/script.cpp
+++ b/wallet/script.cpp
@@ -425,8 +425,9 @@ bool CheckSequence(const int64_t& nSequence, const CTransaction& txTo, unsigned 
     return true;
 }
 
-bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, const CTransaction& txTo,
-                unsigned int nIn, bool fStrictEncodings, int nHashType, ScriptError* serror)
+Result<void, ScriptError> EvalScript(vector<vector<unsigned char>>& stack, const CScript& script,
+                                     const CTransaction& txTo, unsigned int nIn, bool fStrictEncodings,
+                                     int nHashType, ScriptError* serror)
 {
     CAutoBN_CTX             pctx;
     CScript::const_iterator pc             = script.begin();
@@ -438,7 +439,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
     vector<valtype>         altstack;
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     if (script.size() > MAX_SCRIPT_SIZE)
-        return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
+        return Err(SCRIPT_ERR_SCRIPT_SIZE);
     int nOpCount = 0;
 
     try {
@@ -449,11 +450,11 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
             // Read instruction
             //
             if (!script.GetOp(pc, opcode, vchPushValue))
-                return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+                return Err(SCRIPT_ERR_BAD_OPCODE);
             if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
-                return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
+                return Err(SCRIPT_ERR_PUSH_SIZE);
             if (opcode > OP_16 && ++nOpCount > 201)
-                return set_error(serror, SCRIPT_ERR_OP_COUNT);
+                return Err(SCRIPT_ERR_OP_COUNT);
 
             // clang-format off
             if (opcode == OP_CAT ||
@@ -471,7 +472,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 opcode == OP_MOD ||
                 opcode == OP_LSHIFT ||
                 opcode == OP_RSHIFT)
-                return set_error(serror, SCRIPT_ERR_DISABLED_OPCODE); // Disabled opcodes.
+                return Err(SCRIPT_ERR_DISABLED_OPCODE); // Disabled opcodes.
             // clang-format on
 
             if (fExec && 0 <= opcode && opcode <= OP_PUSHDATA4)
@@ -523,7 +524,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     bool fValue = false;
                     if (fExec) {
                         if (stack.size() < 1)
-                            return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                            return Err(SCRIPT_ERR_UNBALANCED_CONDITIONAL);
                         valtype& vch = stacktop(-1);
                         fValue       = CastToBool(vch);
                         if (opcode == OP_NOTIF)
@@ -535,13 +536,13 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
 
                 case OP_ELSE: {
                     if (vfExec.empty())
-                        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                        return Err(SCRIPT_ERR_UNBALANCED_CONDITIONAL);
                     vfExec.back() = !vfExec.back();
                 } break;
 
                 case OP_ENDIF: {
                     if (vfExec.empty())
-                        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                        return Err(SCRIPT_ERR_UNBALANCED_CONDITIONAL);
                     vfExec.pop_back();
                 } break;
 
@@ -549,16 +550,16 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     // (true -- ) or
                     // (false -- false) and return
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     bool fValue = CastToBool(stacktop(-1));
                     if (fValue)
                         popstack(stack);
                     else
-                        return set_error(serror, SCRIPT_ERR_VERIFY);
+                        return Err(SCRIPT_ERR_VERIFY);
                 } break;
 
                 case OP_RETURN: {
-                    return set_error(serror, SCRIPT_ERR_OP_RETURN);
+                    return Err(SCRIPT_ERR_OP_RETURN);
                 } break;
 
                 case OP_CHECKLOCKTIMEVERIFY: {
@@ -571,7 +572,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     }
 
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
 
                     CBigNum nLockTime = CastToBigNum(stacktop(-1));
 
@@ -579,11 +580,11 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     // some arithmetic being done first, you can always use
                     // 0 MAX CHECKLOCKTIMEVERIFY.
                     if (nLockTime < 0)
-                        return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
+                        return Err(SCRIPT_ERR_NEGATIVE_LOCKTIME);
 
                     // Actually compare the specified lock time with the transaction.
                     if (!CheckLockTime(nLockTime.getuint64(), txTo, nIn))
-                        return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+                        return Err(SCRIPT_ERR_UNSATISFIED_LOCKTIME);
 
                     break;
                 }
@@ -594,7 +595,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     break;
 
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
 
                     // nSequence, like nLockTime, is a 32-bit unsigned integer
                     // field. See the comment in CHECKLOCKTIMEVERIFY regarding
@@ -605,7 +606,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     // some arithmetic being done first, you can always use
                     // 0 MAX CHECKSEQUENCEVERIFY.
                     if (nSequence < 0)
-                        return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
+                        return Err(SCRIPT_ERR_NEGATIVE_LOCKTIME);
 
                     // To provide for future soft-fork extensibility, if the
                     // operand has the disabled lock-time flag set,
@@ -615,7 +616,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
 
                     // Compare the specified sequence number with the input.
                     if (!CheckSequence(nSequence.getuint64(), txTo, nIn))
-                        return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+                        return Err(SCRIPT_ERR_UNSATISFIED_LOCKTIME);
 
                     break;
                 }
@@ -625,14 +626,14 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 //
                 case OP_TOALTSTACK: {
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     altstack.push_back(stacktop(-1));
                     popstack(stack);
                 } break;
 
                 case OP_FROMALTSTACK: {
                     if (altstack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_ALTSTACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_ALTSTACK_OPERATION);
                     stack.push_back(altstacktop(-1));
                     popstack(altstack);
                 } break;
@@ -640,7 +641,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_2DROP: {
                     // (x1 x2 -- )
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     popstack(stack);
                     popstack(stack);
                 } break;
@@ -648,7 +649,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_2DUP: {
                     // (x1 x2 -- x1 x2 x1 x2)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch1 = stacktop(-2);
                     valtype vch2 = stacktop(-1);
                     stack.push_back(vch1);
@@ -658,7 +659,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_3DUP: {
                     // (x1 x2 x3 -- x1 x2 x3 x1 x2 x3)
                     if (stack.size() < 3)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch1 = stacktop(-3);
                     valtype vch2 = stacktop(-2);
                     valtype vch3 = stacktop(-1);
@@ -670,7 +671,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_2OVER: {
                     // (x1 x2 x3 x4 -- x1 x2 x3 x4 x1 x2)
                     if (stack.size() < 4)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch1 = stacktop(-4);
                     valtype vch2 = stacktop(-3);
                     stack.push_back(vch1);
@@ -680,7 +681,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_2ROT: {
                     // (x1 x2 x3 x4 x5 x6 -- x3 x4 x5 x6 x1 x2)
                     if (stack.size() < 6)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch1 = stacktop(-6);
                     valtype vch2 = stacktop(-5);
                     stack.erase(stack.end() - 6, stack.end() - 4);
@@ -691,7 +692,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_2SWAP: {
                     // (x1 x2 x3 x4 -- x3 x4 x1 x2)
                     if (stack.size() < 4)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     swap(stacktop(-4), stacktop(-2));
                     swap(stacktop(-3), stacktop(-1));
                 } break;
@@ -699,7 +700,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_IFDUP: {
                     // (x - 0 | x x)
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch = stacktop(-1);
                     if (CastToBool(vch))
                         stack.push_back(vch);
@@ -714,14 +715,14 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_DROP: {
                     // (x -- )
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     popstack(stack);
                 } break;
 
                 case OP_DUP: {
                     // (x -- x x)
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch = stacktop(-1);
                     stack.push_back(vch);
                 } break;
@@ -729,14 +730,14 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_NIP: {
                     // (x1 x2 -- x2)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     stack.erase(stack.end() - 2);
                 } break;
 
                 case OP_OVER: {
                     // (x1 x2 -- x1 x2 x1)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch = stacktop(-2);
                     stack.push_back(vch);
                 } break;
@@ -746,11 +747,11 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     // (xn ... x2 x1 x0 n - xn ... x2 x1 x0 xn)
                     // (xn ... x2 x1 x0 n - ... x2 x1 x0 xn)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     int n = CastToBigNum(stacktop(-1)).getint();
                     popstack(stack);
                     if (n < 0 || n >= (int)stack.size())
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch = stacktop(-n - 1);
                     if (opcode == OP_ROLL)
                         stack.erase(stack.end() - n - 1);
@@ -762,7 +763,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     //  x2 x1 x3  after first swap
                     //  x2 x3 x1  after second swap
                     if (stack.size() < 3)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     swap(stacktop(-3), stacktop(-2));
                     swap(stacktop(-2), stacktop(-1));
                 } break;
@@ -770,14 +771,14 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_SWAP: {
                     // (x1 x2 -- x2 x1)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     swap(stacktop(-2), stacktop(-1));
                 } break;
 
                 case OP_TUCK: {
                     // (x1 x2 -- x2 x1 x2)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype vch = stacktop(-1);
                     stack.insert(stack.end() - 2, vch);
                 } break;
@@ -788,24 +789,24 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_CAT: {
                     // (x1 x2 -- out)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype& vch1 = stacktop(-2);
                     valtype& vch2 = stacktop(-1);
                     vch1.insert(vch1.end(), vch2.begin(), vch2.end());
                     popstack(stack);
                     if (stacktop(-1).size() > MAX_SCRIPT_ELEMENT_SIZE)
-                        return set_error(serror, SCRIPT_ERR_MAX_ELEMENT_SIZE);
+                        return Err(SCRIPT_ERR_MAX_ELEMENT_SIZE);
                 } break;
 
                 case OP_SUBSTR: {
                     // (in begin size -- out)
                     if (stack.size() < 3)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype& vch    = stacktop(-3);
                     int      nBegin = CastToBigNum(stacktop(-2)).getint();
                     int      nEnd   = nBegin + CastToBigNum(stacktop(-1)).getint();
                     if (nBegin < 0 || nEnd < nBegin)
-                        return set_error(serror, SCRIPT_ERR_ELEMENT_SIZE);
+                        return Err(SCRIPT_ERR_ELEMENT_SIZE);
                     if (nBegin > (int)vch.size())
                         nBegin = vch.size();
                     if (nEnd > (int)vch.size())
@@ -820,11 +821,11 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_RIGHT: {
                     // (in size -- out)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype& vch   = stacktop(-2);
                     int      nSize = CastToBigNum(stacktop(-1)).getint();
                     if (nSize < 0)
-                        return set_error(serror, SCRIPT_ERR_ELEMENT_SIZE);
+                        return Err(SCRIPT_ERR_ELEMENT_SIZE);
                     if (nSize > (int)vch.size())
                         nSize = vch.size();
                     if (opcode == OP_LEFT)
@@ -837,7 +838,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_SIZE: {
                     // (in -- in size)
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     CBigNum bn(stacktop(-1).size());
                     stack.push_back(bn.getvch());
                 } break;
@@ -848,7 +849,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_INVERT: {
                     // (in - out)
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype& vch = stacktop(-1);
                     for (unsigned int i = 0; i < vch.size(); i++)
                         vch[i] = ~vch[i];
@@ -864,7 +865,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_XOR: {
                     // (x1 x2 - out)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype& vch1 = stacktop(-2);
                     valtype& vch2 = stacktop(-1);
                     MakeSameSize(vch1, vch2); // <-- NOT SAFE FOR SIGNED VALUES
@@ -887,7 +888,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                     {
                         // (x1 x2 - bool)
                         if (stack.size() < 2)
-                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                            return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                         valtype& vch1   = stacktop(-2);
                         valtype& vch2   = stacktop(-1);
                         bool     fEqual = (vch1 == vch2);
@@ -903,7 +904,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                             if (fEqual)
                                 popstack(stack);
                             else
-                                return set_error(serror, SCRIPT_ERR_EQUALVERIFY);
+                                return Err(SCRIPT_ERR_EQUALVERIFY);
                         }
                     }
                     break;
@@ -921,7 +922,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_0NOTEQUAL: {
                     // (in -- out)
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     CBigNum bn = CastToBigNum(stacktop(-1));
                     // clang-format off
                     switch (opcode)
@@ -961,7 +962,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_MAX: {
                     // (x1 x2 -- out)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     CBigNum bn1 = CastToBigNum(stacktop(-2));
                     CBigNum bn2 = CastToBigNum(stacktop(-1));
                     CBigNum bn;
@@ -976,28 +977,28 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
 
                     case OP_MUL:
                         if (!BN_mul(bn.get_raw(), bn1.get_raw(), bn2.get_raw(), pctx))
-                            return set_error(serror, SCRIPT_ERR_ARITHMETIC_OP_FAILED);
+                            return Err(SCRIPT_ERR_ARITHMETIC_OP_FAILED);
                         break;
 
                     case OP_DIV:
                         if (!BN_div(bn.get_raw(), NULL, bn1.get_raw(), bn2.get_raw(), pctx))
-                            return set_error(serror, SCRIPT_ERR_ARITHMETIC_OP_FAILED);
+                            return Err(SCRIPT_ERR_ARITHMETIC_OP_FAILED);
                         break;
 
                     case OP_MOD:
                         if (!BN_mod(bn.get_raw(), bn1.get_raw(), bn2.get_raw(), pctx))
-                            return set_error(serror, SCRIPT_ERR_ARITHMETIC_OP_FAILED);
+                            return Err(SCRIPT_ERR_ARITHMETIC_OP_FAILED);
                         break;
 
                     case OP_LSHIFT:
                         if (bn2 < bnZero || bn2 > CBigNum(2048))
-                            return set_error(serror, SCRIPT_ERR_ARITHMETIC_OP_FAILED);
+                            return Err(SCRIPT_ERR_ARITHMETIC_OP_FAILED);
                         bn = bn1 << bn2.getulong();
                         break;
 
                     case OP_RSHIFT:
                         if (bn2 < bnZero || bn2 > CBigNum(2048))
-                            return set_error(serror, SCRIPT_ERR_ARITHMETIC_OP_FAILED);
+                            return Err(SCRIPT_ERR_ARITHMETIC_OP_FAILED);
                         bn = bn1 >> bn2.getulong();
                         break;
                     // clang-format off
@@ -1025,14 +1026,14 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                         if (CastToBool(stacktop(-1)))
                             popstack(stack);
                         else
-                            return set_error(serror, SCRIPT_ERR_NUMEQUALVERIFY);
+                            return Err(SCRIPT_ERR_NUMEQUALVERIFY);
                     }
                 } break;
 
                 case OP_WITHIN: {
                     // (x min max -- out)
                     if (stack.size() < 3)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     CBigNum bn1    = CastToBigNum(stacktop(-3));
                     CBigNum bn2    = CastToBigNum(stacktop(-2));
                     CBigNum bn3    = CastToBigNum(stacktop(-1));
@@ -1053,7 +1054,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_HASH256: {
                     // (in -- hash)
                     if (stack.size() < 1)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
                     valtype& vch = stacktop(-1);
                     valtype  vchHash(
                         (opcode == OP_RIPEMD160 || opcode == OP_SHA1 || opcode == OP_HASH160) ? 20 : 32);
@@ -1083,7 +1084,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                 case OP_CHECKSIGVERIFY: {
                     // (sig pubkey -- bool)
                     if (stack.size() < 2)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
 
                     valtype& vchSig    = stacktop(-2);
                     valtype& vchPubKey = stacktop(-1);
@@ -1106,7 +1107,7 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                         if (fSuccess)
                             popstack(stack);
                         else
-                            return set_error(serror, SCRIPT_ERR_OP_CHECKSIGVERIFY_FAILED);
+                            return Err(SCRIPT_ERR_OP_CHECKSIGVERIFY_FAILED);
                     }
                 } break;
 
@@ -1116,26 +1117,26 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
 
                     int i = 1;
                     if ((int)stack.size() < i)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
 
                     int nKeysCount = CastToBigNum(stacktop(-i)).getint();
                     if (nKeysCount < 0 || nKeysCount > 20)
-                        return set_error(serror, SCRIPT_ERR_PUBKEY_COUNT);
+                        return Err(SCRIPT_ERR_PUBKEY_COUNT);
                     nOpCount += nKeysCount;
                     if (nOpCount > 201)
-                        return set_error(serror, SCRIPT_ERR_OP_COUNT);
+                        return Err(SCRIPT_ERR_OP_COUNT);
                     int ikey = ++i;
                     i += nKeysCount;
                     if ((int)stack.size() < i)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
 
                     int nSigsCount = CastToBigNum(stacktop(-i)).getint();
                     if (nSigsCount < 0 || nSigsCount > nKeysCount)
-                        return set_error(serror, SCRIPT_ERR_SIG_COUNT);
+                        return Err(SCRIPT_ERR_SIG_COUNT);
                     int isig = ++i;
                     i += nSigsCount;
                     if ((int)stack.size() < i)
-                        return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        return Err(SCRIPT_ERR_INVALID_STACK_OPERATION);
 
                     // Subset of script starting at the most recent codeseparator
                     CScript scriptCode(pbegincodehash, pend);
@@ -1178,32 +1179,32 @@ bool EvalScript(vector<vector<unsigned char>>& stack, const CScript& script, con
                         if (fSuccess)
                             popstack(stack);
                         else
-                            return set_error(serror, SCRIPT_ERR_CHECKMULTISIGVERIFY);
+                            return Err(SCRIPT_ERR_CHECKMULTISIGVERIFY);
                     }
                 } break;
                 case OP_CHECKCOLDSTAKEVERIFY: {
                     // check it is used in a valid cold stake transaction.
                     if (!txTo.CheckColdStake(script)) {
-                        return set_error(serror, SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
+                        return Err(SCRIPT_ERR_CHECKCOLDSTAKEVERIFY);
                     }
                 } break;
 
                 default:
-                    return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+                    return Err(SCRIPT_ERR_BAD_OPCODE);
                 }
 
             // Size limits
             if (stack.size() + altstack.size() > 1000)
-                return set_error(serror, SCRIPT_ERR_STACK_SIZE);
+                return Err(SCRIPT_ERR_STACK_SIZE);
         }
     } catch (...) {
-        return set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
+        return Err(SCRIPT_ERR_UNKNOWN_ERROR);
     }
 
     if (!vfExec.empty())
-        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+        return Err(SCRIPT_ERR_UNBALANCED_CONDITIONAL);
 
-    return set_success(serror);
+    return Ok();
 }
 
 //////////////////////////
@@ -1798,48 +1799,50 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet,
     return true;
 }
 
-bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CTransaction& txTo,
-                  unsigned int nIn, bool fValidatePayToScriptHash, bool fStrictEncodings, int nHashType,
-                  ScriptError* serror)
+Result<void, ScriptError> VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey,
+                                       const CTransaction& txTo, unsigned int nIn,
+                                       bool fValidatePayToScriptHash, bool fStrictEncodings,
+                                       int nHashType)
 {
-    set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
 
     vector<vector<unsigned char>> stack, stackCopy;
-    if (!EvalScript(stack, scriptSig, txTo, nIn, fStrictEncodings, nHashType))
-        return false;
+
+    TRYV(EvalScript(stack, scriptSig, txTo, nIn, fStrictEncodings, nHashType));
+
     if (fValidatePayToScriptHash)
         stackCopy = stack;
-    if (!EvalScript(stack, scriptPubKey, txTo, nIn, fStrictEncodings, nHashType))
-        return false;
+
+    TRYV(EvalScript(stack, scriptPubKey, txTo, nIn, fStrictEncodings, nHashType));
+
     if (stack.empty())
-        return set_error(serror, SCRIPT_ERR_EVAL_FALSE);
+        return Err(SCRIPT_ERR_EVAL_FALSE);
 
     if (CastToBool(stack.back()) == false)
-        return set_error(serror, SCRIPT_ERR_EVAL_FALSE);
+        return Err(SCRIPT_ERR_EVAL_FALSE);
 
     // Additional validation for spend-to-script-hash transactions:
     if (scriptPubKey.IsPayToScriptHash()) {
         if (!scriptSig.IsPushOnly()) // scriptSig must be literals-only
-            return set_error(serror, SCRIPT_ERR_SIG_PUSHONLY);
+            return Err(SCRIPT_ERR_SIG_PUSHONLY);
 
         if (stackCopy.empty()) // Check to make sure that the stackCopy has elements too
-            return false;
+            return Err(SCRIPT_ERR_UNKNOWN_ERROR);
 
         const valtype& pubKeySerialized = stackCopy.back();
         CScript        pubKey2(pubKeySerialized.begin(), pubKeySerialized.end());
         popstack(stackCopy);
 
-        if (!EvalScript(stackCopy, pubKey2, txTo, nIn, fStrictEncodings, nHashType))
-            return false;
+        TRYV(EvalScript(stackCopy, pubKey2, txTo, nIn, fStrictEncodings, nHashType));
+
         if (stackCopy.empty())
-            return set_error(serror, SCRIPT_ERR_EVAL_FALSE);
+            return Err(SCRIPT_ERR_EVAL_FALSE);
         if (!CastToBool(stackCopy.back()))
-            return set_error(serror, SCRIPT_ERR_EVAL_FALSE);
+            return Err(SCRIPT_ERR_EVAL_FALSE);
         else
-            return set_success(serror);
+            return Ok();
     }
 
-    return set_success(serror);
+    return Ok();
 }
 
 SignatureState SignSignature(const CKeyStore& keystore, const CScript& fromPubKey, CTransaction& txTo,
@@ -1875,7 +1878,7 @@ SignatureState SignSignature(const CKeyStore& keystore, const CScript& fromPubKe
     }
 
     // Test solution
-    if (!fColdStake && VerifyScript(txin.scriptSig, fromPubKey, txTo, nIn, true, true, 0)) {
+    if (!fColdStake && VerifyScript(txin.scriptSig, fromPubKey, txTo, nIn, true, true, 0).isOk()) {
         return SignatureState::Verified;
     }
     // we don't verify cold stakes because the verification is transaction dependent, not input dependent
@@ -1909,7 +1912,8 @@ bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsig
         return false;
 
     return VerifyScript(txin.scriptSig, txout.scriptPubKey, txTo, nIn, fValidatePayToScriptHash,
-                        fStrictEncodings, nHashType);
+                        fStrictEncodings, nHashType)
+        .isOk();
 }
 
 static CScript PushAll(const vector<valtype>& values)

--- a/wallet/script.h
+++ b/wallet/script.h
@@ -16,6 +16,7 @@
 
 #include "bignum.h"
 #include "keystore.h"
+#include "result.h"
 #include "script_error.h"
 #include "wallet_ismine.h"
 
@@ -678,13 +679,14 @@ bool IsCanonicalSignature(const std::vector<unsigned char>& vchSig);
 
 CScript GetScriptForDestination(const CTxDestination& dest);
 CScript GetScriptForStakeDelegation(const CKeyID& stakingKey, const CKeyID& spendingKey);
-bool    EvalScript(std::vector<std::vector<unsigned char>>& stack, const CScript& script,
-                   const CTransaction& txTo, unsigned int nIn, bool fStrictEncodings, int nHashType,
-                   ScriptError* serror = nullptr);
-bool    Solver(const CScript& scriptPubKey, txnouttype& typeRet,
-               std::vector<std::vector<unsigned char>>& vSolutionsRet);
-int     ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned char>>& vSolutions);
-bool    IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
+Result<void, ScriptError> EvalScript(std::vector<std::vector<unsigned char>>& stack,
+                                     const CScript& script, const CTransaction& txTo, unsigned int nIn,
+                                     bool fStrictEncodings, int nHashType,
+                                     ScriptError* serror = nullptr);
+bool                      Solver(const CScript& scriptPubKey, txnouttype& typeRet,
+                                 std::vector<std::vector<unsigned char>>& vSolutionsRet);
+int  ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned char>>& vSolutions);
+bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey);
 isminetype IsMine(const CKeyStore& keystore, const CTxDestination& dest);
 
@@ -698,9 +700,10 @@ SignatureState SignSignature(const CKeyStore& keystore, const CScript& fromPubKe
                              unsigned int nIn, int nHashType = SIGHASH_ALL, bool fColdStake = false);
 SignatureState SignSignature(const CKeyStore& keystore, const CTransaction& txFrom, CTransaction& txTo,
                              unsigned int nIn, int nHashType = SIGHASH_ALL, bool fColdStake = false);
-bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CTransaction& txTo,
-                  unsigned int nIn, bool fValidatePayToScriptHash, bool fStrictEncodings, int nHashType,
-                  ScriptError* serror = nullptr);
+Result<void, ScriptError> VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey,
+                                       const CTransaction& txTo, unsigned int nIn,
+                                       bool fValidatePayToScriptHash, bool fStrictEncodings,
+                                       int nHashType);
 bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int nIn,
                      bool fValidatePayToScriptHash, bool fStrictEncodings, int nHashType);
 

--- a/wallet/script.h
+++ b/wallet/script.h
@@ -704,8 +704,9 @@ Result<void, ScriptError> VerifyScript(const CScript& scriptSig, const CScript& 
                                        const CTransaction& txTo, unsigned int nIn,
                                        bool fValidatePayToScriptHash, bool fStrictEncodings,
                                        int nHashType);
-bool VerifySignature(const CTransaction& txFrom, const CTransaction& txTo, unsigned int nIn,
-                     bool fValidatePayToScriptHash, bool fStrictEncodings, int nHashType);
+Result<void, ScriptError> VerifySignature(const CTransaction& txFrom, const CTransaction& txTo,
+                                          unsigned int nIn, bool fValidatePayToScriptHash,
+                                          bool fStrictEncodings, int nHashType);
 
 // Given two sets of signatures for scriptPubKey, possibly with OP_0 placeholders,
 // combine them intelligently and return the result.

--- a/wallet/script_error.cpp
+++ b/wallet/script_error.cpp
@@ -8,71 +8,79 @@
 
 const char* ScriptErrorString(const ScriptError serror)
 {
-    switch (serror)
-    {
-        case SCRIPT_ERR_OK:
-            return "No error";
-        case SCRIPT_ERR_EVAL_FALSE:
-            return "Script evaluated without error but finished with a false/empty top stack element";
-        case SCRIPT_ERR_VERIFY:
-            return "Script failed an OP_VERIFY operation";
-        case SCRIPT_ERR_EQUALVERIFY:
-            return "Script failed an OP_EQUALVERIFY operation";
-        case SCRIPT_ERR_CHECKCOLDSTAKEVERIFY:
-            return "Script failed an OP_CHECKCOLDSTAKEVERIFY operation";
-        case SCRIPT_ERR_CHECKMULTISIGVERIFY:
-            return "Script failed an OP_CHECKMULTISIGVERIFY operation";
-        case SCRIPT_ERR_CHECKSIGVERIFY:
-            return "Script failed an OP_CHECKSIGVERIFY operation";
-        case SCRIPT_ERR_NUMEQUALVERIFY:
-            return "Script failed an OP_NUMEQUALVERIFY operation";
-        case SCRIPT_ERR_SCRIPT_SIZE:
-            return "Script is too big";
-        case SCRIPT_ERR_PUSH_SIZE:
-            return "Push value size limit exceeded";
-        case SCRIPT_ERR_OP_COUNT:
-            return "Operation limit exceeded";
-        case SCRIPT_ERR_STACK_SIZE:
-            return "Stack size limit exceeded";
-        case SCRIPT_ERR_SIG_COUNT:
-            return "Signature count negative or greater than pubkey count";
-        case SCRIPT_ERR_PUBKEY_COUNT:
-            return "Pubkey count negative or limit exceeded";
-        case SCRIPT_ERR_BAD_OPCODE:
-            return "Opcode missing or not understood";
-        case SCRIPT_ERR_DISABLED_OPCODE:
-            return "Attempted to use a disabled opcode";
-        case SCRIPT_ERR_INVALID_STACK_OPERATION:
-            return "Operation not valid with the current stack size";
-        case SCRIPT_ERR_INVALID_ALTSTACK_OPERATION:
-            return "Operation not valid with the current altstack size";
-        case SCRIPT_ERR_OP_RETURN:
-            return "OP_RETURN was encountered";
-        case SCRIPT_ERR_UNBALANCED_CONDITIONAL:
-            return "Invalid OP_IF construction";
-        case SCRIPT_ERR_NEGATIVE_LOCKTIME:
-            return "Negative locktime";
-        case SCRIPT_ERR_UNSATISFIED_LOCKTIME:
-            return "Locktime requirement not satisfied";
-        case SCRIPT_ERR_SIG_HASHTYPE:
-            return "Signature hash type missing or not understood";
-        case SCRIPT_ERR_SIG_DER:
-            return "Non-canonical DER signature";
-        case SCRIPT_ERR_MINIMALDATA:
-            return "Data push larger than necessary";
-        case SCRIPT_ERR_SIG_PUSHONLY:
-            return "Only non-push operators allowed in signatures";
-        case SCRIPT_ERR_SIG_HIGH_S:
-            return "Non-canonical signature: S value is unnecessarily high";
-        case SCRIPT_ERR_SIG_NULLDUMMY:
-            return "Dummy CHECKMULTISIG argument must be zero";
-        case SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS:
-            return "NOPx reserved for soft-fork upgrades";
-        case SCRIPT_ERR_PUBKEYTYPE:
-            return "Public key is neither compressed or uncompressed";
-        case SCRIPT_ERR_UNKNOWN_ERROR:
-        case SCRIPT_ERR_ERROR_COUNT:
-        default: break;
+    switch (serror) {
+    case SCRIPT_ERR_OK:
+        return "No error";
+    case SCRIPT_ERR_EVAL_FALSE:
+        return "Script evaluated without error but finished with a false/empty top stack element";
+    case SCRIPT_ERR_VERIFY:
+        return "Script failed an OP_VERIFY operation";
+    case SCRIPT_ERR_EQUALVERIFY:
+        return "Script failed an OP_EQUALVERIFY operation";
+    case SCRIPT_ERR_CHECKCOLDSTAKEVERIFY:
+        return "Script failed an OP_CHECKCOLDSTAKEVERIFY operation";
+    case SCRIPT_ERR_CHECKMULTISIGVERIFY:
+        return "Script failed an OP_CHECKMULTISIGVERIFY operation";
+    case SCRIPT_ERR_CHECKSIGVERIFY:
+        return "Script failed an OP_CHECKSIGVERIFY operation";
+    case SCRIPT_ERR_NUMEQUALVERIFY:
+        return "Script failed an OP_NUMEQUALVERIFY operation";
+    case SCRIPT_ERR_SCRIPT_SIZE:
+        return "Script is too big";
+    case SCRIPT_ERR_PUSH_SIZE:
+        return "Push value size limit exceeded";
+    case SCRIPT_ERR_OP_COUNT:
+        return "Operation limit exceeded";
+    case SCRIPT_ERR_STACK_SIZE:
+        return "Stack size limit exceeded";
+    case SCRIPT_ERR_SIG_COUNT:
+        return "Signature count negative or greater than pubkey count";
+    case SCRIPT_ERR_PUBKEY_COUNT:
+        return "Pubkey count negative or limit exceeded";
+    case SCRIPT_ERR_BAD_OPCODE:
+        return "Opcode missing or not understood";
+    case SCRIPT_ERR_DISABLED_OPCODE:
+        return "Attempted to use a disabled opcode";
+    case SCRIPT_ERR_INVALID_STACK_OPERATION:
+        return "Operation not valid with the current stack size";
+    case SCRIPT_ERR_INVALID_ALTSTACK_OPERATION:
+        return "Operation not valid with the current altstack size";
+    case SCRIPT_ERR_OP_RETURN:
+        return "OP_RETURN was encountered";
+    case SCRIPT_ERR_UNBALANCED_CONDITIONAL:
+        return "Invalid OP_IF construction";
+    case SCRIPT_ERR_NEGATIVE_LOCKTIME:
+        return "Negative locktime";
+    case SCRIPT_ERR_UNSATISFIED_LOCKTIME:
+        return "Locktime requirement not satisfied";
+    case SCRIPT_ERR_SIG_HASHTYPE:
+        return "Signature hash type missing or not understood";
+    case SCRIPT_ERR_SIG_DER:
+        return "Non-canonical DER signature";
+    case SCRIPT_ERR_MINIMALDATA:
+        return "Data push larger than necessary";
+    case SCRIPT_ERR_SIG_PUSHONLY:
+        return "Only non-push operators allowed in signatures";
+    case SCRIPT_ERR_SIG_HIGH_S:
+        return "Non-canonical signature: S value is unnecessarily high";
+    case SCRIPT_ERR_SIG_NULLDUMMY:
+        return "Dummy CHECKMULTISIG argument must be zero";
+    case SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS:
+        return "NOPx reserved for soft-fork upgrades";
+    case SCRIPT_ERR_PUBKEYTYPE:
+        return "Public key is neither compressed or uncompressed";
+    case SCRIPT_ERR_MAX_ELEMENT_SIZE:
+        return "Element size in stack larger than maximum";
+    case SCRIPT_ERR_ELEMENT_SIZE:
+        return "Invalid index for element";
+    case SCRIPT_ERR_ARITHMETIC_OP_FAILED:
+        return "Arithmetic script operation failed";
+    case SCRIPT_ERR_OP_CHECKSIGVERIFY_FAILED:
+        return "Signature verification failed";
+    case SCRIPT_ERR_UNKNOWN_ERROR:
+        return "Unknown error";
+    case SCRIPT_ERR_ERROR_COUNT:
+        break;
     }
     return "unknown error";
 }

--- a/wallet/stakemaker.cpp
+++ b/wallet/stakemaker.cpp
@@ -234,8 +234,9 @@ bool StakeMaker::SignAndVerify(const CKeyStore& keystore, const CoinStakeInputsR
         if (sigStates[i] == SignatureState::Verified) {
             continue;
         }
-        if (!VerifyScript(stakeTx.vin[i].scriptSig, pcoin->vout[txin.prevout.n].scriptPubKey, stakeTx, i,
-                          true, true, 0)) {
+        if (VerifyScript(stakeTx.vin[i].scriptSig, pcoin->vout[txin.prevout.n].scriptPubKey, stakeTx, i,
+                         true, true, 0)
+                .isErr()) {
             printf("CreateCoinStake : Signature verification failed");
             return false;
         }

--- a/wallet/test/CMakeLists.txt
+++ b/wallet/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(neblio-tests
     ntp1_tests.cpp
     pmt_tests.cpp
     pos_tests.cpp
+    result_tests.cpp
     rpc_tests.cpp
     script_tests.cpp
     serialize_tests.cpp

--- a/wallet/test/bloom_tests.cpp
+++ b/wallet/test/bloom_tests.cpp
@@ -226,7 +226,7 @@ TEST(bloom_tests, bloom_match)
     CDataStream  stream(ParseHex(transactionStr), SER_NETWORK, PROTOCOL_VERSION);
     CTransaction tx;
     stream >> tx;
-    EXPECT_TRUE(tx.CheckTransaction()) << "Simple deserialized transaction should be valid.";
+    EXPECT_TRUE(tx.CheckTransaction().isOk()) << "Simple deserialized transaction should be valid.";
 
     string spendTransaction =
         "010000004d73435a01d3db1c519251eeecc76b3c68e550988290aa1d7c63d6b396b0ad069ebe987335000000006b483"
@@ -237,7 +237,7 @@ TEST(bloom_tests, bloom_match)
     CDataStream  spendStream(ParseHex(spendTransaction), SER_NETWORK, PROTOCOL_VERSION);
     CTransaction spendingTx;
     spendStream >> spendingTx;
-    EXPECT_TRUE(spendingTx.CheckTransaction())
+    EXPECT_TRUE(spendingTx.CheckTransaction().isOk())
         << "Simple deserialized of spending transaction should be valid.";
 
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);

--- a/wallet/test/crypter_tests.cpp
+++ b/wallet/test/crypter_tests.cpp
@@ -349,7 +349,7 @@ TEST(cryptography_tests, ecdh_get_scriptSig)
     CTransaction tx = TxFromHex_crypterTests(transaction);
 
     std::vector<std::vector<unsigned char>> stack;
-    EXPECT_TRUE(EvalScript(stack, tx.vin[0].scriptSig, tx, 1, false, 0));
+    EXPECT_TRUE(EvalScript(stack, tx.vin[0].scriptSig, tx, 1, false, 0).isOk());
 
     boost::optional<CKey> pubKey = CTransaction::GetPublicKeyFromScriptSig(tx.vin[0].scriptSig);
 

--- a/wallet/test/ntp1_tests.cpp
+++ b/wallet/test/ntp1_tests.cpp
@@ -695,7 +695,7 @@ TEST(ntp1_tests, parsig_ntp1_from_ctransaction_issuance)
     CTransaction tx = TxFromHex(transaction);
     EXPECT_EQ(tx.GetHash().ToString(),
               "66216fa9cc0167568c3e5f8b66e7fe3690072f66a5f41df222327de7af10ff80");
-    EXPECT_TRUE(tx.CheckTransaction());
+    EXPECT_TRUE(tx.CheckTransaction().isOk());
 
     std::string opReturnArg;
     EXPECT_TRUE(NTP1Transaction::IsTxNTP1(&tx, &opReturnArg));
@@ -781,7 +781,7 @@ TEST(ntp1_tests, parsig_ntp1_from_ctransaction_transfer_1)
         "9211705770db88ac10270000000000000e6a0c4e5401150020120169895242409c0000000000001976a9143f7eb"
         "8c3da2cbe606fd5d46b11ab9211705770db88ac00000000";
     CTransaction tx = TxFromHex(transaction);
-    EXPECT_TRUE(tx.CheckTransaction());
+    EXPECT_TRUE(tx.CheckTransaction().isOk());
 
     std::string opReturnArg;
     EXPECT_TRUE(NTP1Transaction::IsTxNTP1(&tx, &opReturnArg));
@@ -981,7 +981,7 @@ TEST(ntp1_tests, parsig_ntp1_from_ctransaction_transfer_2_with_change)
         "9211705770db88ac10270000000000000e6a0c4e5401150020120169895242409c0000000000001976a9143f7eb"
         "8c3da2cbe606fd5d46b11ab9211705770db88ac00000000";
     CTransaction tx = TxFromHex(transaction);
-    EXPECT_TRUE(tx.CheckTransaction());
+    EXPECT_TRUE(tx.CheckTransaction().isOk());
 
     std::string opReturnArg;
     EXPECT_TRUE(NTP1Transaction::IsTxNTP1(&tx, &opReturnArg));
@@ -1188,7 +1188,7 @@ TEST(ntp1_tests, parsig_ntp1_from_ctransaction_burn_with_transfer_1)
         "000000000a6a084e540125000a1f1410270000000000001976a9143f7eb8c3da2cbe606fd5d46b11ab921170577"
         "0db88ac00000000";
     CTransaction tx = TxFromHex(transaction);
-    EXPECT_TRUE(tx.CheckTransaction());
+    EXPECT_TRUE(tx.CheckTransaction().isOk());
 
     std::string vinA =
         "010000005944185b0226d0e3af9cf2fa36d2cbecd53d54dc68e35489c85fae907e050165dc1a980413010000006"
@@ -1693,7 +1693,7 @@ void TestNTP1TxParsing(const CTransaction& tx, NetworkType netType)
 {
     const std::string&    txid       = tx.GetHash().ToString();
     const NTP1Transaction ntp1tx_ref = NTP1APICalls::RetrieveData_TransactionInfo(txid, netType);
-    EXPECT_TRUE(tx.CheckTransaction()) << "Failed tx: " << txid;
+    EXPECT_TRUE(tx.CheckTransaction().isOk()) << "Failed tx: " << txid;
 
     std::vector<std::pair<CTransaction, NTP1Transaction>> inputs;
 
@@ -1802,7 +1802,7 @@ void TestSingleNTP1TxParsingLocally(const CTransaction&                       tx
 
     NTP1Transaction ntp1tx_ref;
     ntp1tx_ref.importJsonData(ntp1tx_ref_str);
-    EXPECT_TRUE(tx.CheckTransaction()) << "Failed tx: " << txid;
+    EXPECT_TRUE(tx.CheckTransaction().isOk()) << "Failed tx: " << txid;
 
     std::string OpReturnArg;
     EXPECT_TRUE(NTP1Transaction::IsTxNTP1(&tx, &OpReturnArg));

--- a/wallet/test/result_tests.cpp
+++ b/wallet/test/result_tests.cpp
@@ -1,0 +1,47 @@
+#include "googletest/googletest/include/gtest/gtest.h"
+
+#include "result.h"
+
+TEST(result_tests, basic)
+{
+    {
+        Result<uint64_t, uint32_t> r1 = Ok(UINT64_C(3));
+
+        auto val = r1.expect("Failed to retrieve the value");
+        EXPECT_EQ(val, 3);
+    }
+    {
+        Result<std::string, uint32_t> r1 = Ok(std::string("Success!"));
+
+        auto val = r1.expect("Failed to retrieve the value");
+        EXPECT_EQ(val, "Success!");
+    }
+    {
+        const std::string str("Success!");
+
+        Result<std::string, uint32_t> r1 = Ok(str);
+
+        auto val = r1.expect("Failed to retrieve the value");
+        EXPECT_EQ(val, "Success!");
+    }
+    {
+        Result<std::string, uint32_t> r1 = Err(15u);
+
+        EXPECT_TRUE(r1.isErr());
+        EXPECT_EQ(r1.unwrapErr(), 15);
+    }
+    {
+        Result<uint32_t, std::string> r1 = Err(std::string("Error!"));
+
+        EXPECT_TRUE(r1.isErr());
+        EXPECT_EQ(r1.unwrapErr(), "Error!");
+    }
+    {
+        const std::string str("Success!");
+
+        Result<uint32_t, std::string> r1 = Err(str);
+
+        EXPECT_TRUE(r1.isErr());
+        EXPECT_EQ(r1.unwrapErr(), str);
+    }
+}

--- a/wallet/test/result_tests.cpp
+++ b/wallet/test/result_tests.cpp
@@ -2,46 +2,77 @@
 
 #include "result.h"
 
-TEST(result_tests, basic)
+TEST(result_tests, basic_result)
 {
-    {
-        Result<uint64_t, uint32_t> r1 = Ok(UINT64_C(3));
+    Result<uint64_t, uint32_t> r1 = Ok(UINT64_C(3));
 
-        auto val = r1.expect("Failed to retrieve the value");
-        EXPECT_EQ(val, 3);
-    }
-    {
-        Result<std::string, uint32_t> r1 = Ok(std::string("Success!"));
+    auto val = r1.expect("Failed to retrieve the value");
+    EXPECT_EQ(val, 3);
+}
 
-        auto val = r1.expect("Failed to retrieve the value");
-        EXPECT_EQ(val, "Success!");
-    }
-    {
-        const std::string str("Success!");
+TEST(result_tests, rvalue_result)
+{
+    Result<std::string, uint32_t> r1 = Ok(std::string("Success!"));
 
-        Result<std::string, uint32_t> r1 = Ok(str);
+    auto val = r1.expect("Failed to retrieve the value");
+    EXPECT_EQ(val, "Success!");
+}
 
-        auto val = r1.expect("Failed to retrieve the value");
-        EXPECT_EQ(val, "Success!");
-    }
-    {
-        Result<std::string, uint32_t> r1 = Err(15u);
+TEST(result_tests, rvalue_result_forced)
 
-        EXPECT_TRUE(r1.isErr());
-        EXPECT_EQ(r1.unwrapErr(), 15);
-    }
-    {
-        Result<uint32_t, std::string> r1 = Err(std::string("Error!"));
+{
+    std::string                   str("Success!");
+    Result<std::string, uint32_t> r1 = Ok(std::move(str));
 
-        EXPECT_TRUE(r1.isErr());
-        EXPECT_EQ(r1.unwrapErr(), "Error!");
-    }
-    {
-        const std::string str("Success!");
+    EXPECT_TRUE(str.empty());
 
-        Result<uint32_t, std::string> r1 = Err(str);
+    auto val = r1.expect("Failed to retrieve the value");
+    EXPECT_EQ(val, "Success!");
+}
 
-        EXPECT_TRUE(r1.isErr());
-        EXPECT_EQ(r1.unwrapErr(), str);
-    }
+TEST(result_tests, rvalue_error_forced)
+{
+    std::string                   str("Success!");
+    Result<uint32_t, std::string> r1 = Err(std::move(str));
+
+    EXPECT_TRUE(str.empty());
+    EXPECT_TRUE(r1.isErr());
+
+    EXPECT_EQ(r1.unwrapErr(), "Success!");
+}
+
+TEST(result_tests, lvalue_result)
+{
+    const std::string str("Success!");
+
+    Result<std::string, uint32_t> r1 = Ok(str);
+
+    auto val = r1.expect("Failed to retrieve the value");
+    EXPECT_EQ(val, "Success!");
+}
+
+TEST(result_tests, basic_error)
+{
+    Result<std::string, uint32_t> r1 = Err(15u);
+
+    EXPECT_TRUE(r1.isErr());
+    EXPECT_EQ(r1.unwrapErr(), 15);
+}
+
+TEST(result_tests, rvalue_error)
+{
+    Result<uint32_t, std::string> r1 = Err(std::string("Error!"));
+
+    EXPECT_TRUE(r1.isErr());
+    EXPECT_EQ(r1.unwrapErr(), "Error!");
+}
+
+TEST(result_tests, lvalue_error)
+{
+    const std::string str("Success!");
+
+    Result<uint32_t, std::string> r1 = Err(str);
+
+    EXPECT_TRUE(r1.isErr());
+    EXPECT_EQ(r1.unwrapErr(), str);
 }

--- a/wallet/test/transaction_tests.cpp
+++ b/wallet/test/transaction_tests.cpp
@@ -71,7 +71,8 @@ TEST(transaction_tests, tx_valid)
                     break;
                 }
                 EXPECT_TRUE(VerifyScript(tx.vin[i].scriptSig, mapprevOutScriptPubKeys[tx.vin[i].prevout],
-                                         tx, i, test[2].get_bool(), false, 0))
+                                         tx, i, test[2].get_bool(), false, 0)
+                                .isOk())
                     << strTest;
             }
         }
@@ -132,7 +133,8 @@ TEST(transaction_tests, tx_invalid)
                     break;
                 }
                 fValid = VerifyScript(tx.vin[i].scriptSig, mapprevOutScriptPubKeys[tx.vin[i].prevout],
-                                      tx, i, test[2].get_bool(), true, 0);
+                                      tx, i, test[2].get_bool(), true, 0)
+                             .isOk();
             }
 
             EXPECT_TRUE(!fValid) << strTest;

--- a/wallet/transaction.cpp
+++ b/wallet/transaction.cpp
@@ -220,61 +220,62 @@ unsigned int CTransaction::GetLegacySigOpCount() const
 
 Result<void, TxValidationState> CTransaction::CheckTransaction(CBlock* sourceBlockPtr) const
 {
-    // TODOVAL: take care of DoS
     // Basic checks that don't depend on any context
-    if (vin.empty())
-        //        return DoS(10, error("CTransaction::CheckTransaction() : vin empty"));
+    if (vin.empty()) {
+        DoS(10, false);
         return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-vin-empty"));
-    if (vout.empty())
-        //        return DoS(10, error("CTransaction::CheckTransaction() : vout empty"));
+    }
+    if (vout.empty()) {
+        DoS(10, false);
         return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-empty"));
+    }
 
     // Size limits
     unsigned int nSizeLimit = MaxBlockSize();
-    if (::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION) > nSizeLimit)
-        //        return DoS(100, error("CTransaction::CheckTransaction() : size limits failed"));
+    if (::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION) > nSizeLimit) {
+        DoS(100, false);
         return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-oversize"));
+    }
 
     // Check for negative or overflow output values
     CAmount nValueOut = 0;
     for (unsigned int i = 0; i < vout.size(); i++) {
         const CTxOut& txout = vout[i];
-        if (txout.IsEmpty() && !IsCoinBase() && !IsCoinStake())
-            // return DoS(100,error("CTransaction::CheckTransaction() : txout empty for user
-            // transaction"));
+        if (txout.IsEmpty() && !IsCoinBase() && !IsCoinStake()) {
+            DoS(100, false);
             return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "txout-empty-for-tx"));
+        }
 
-        if (txout.nValue < 0)
-            // return DoS(100, error("CTransaction::CheckTransaction() : txout.nValue negative (%zi)",
-            // txout.nValue));
+        if (txout.nValue < 0) {
+            DoS(100, false);
             return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-negative"));
+        }
 
-        if (txout.nValue > MAX_MONEY)
-            // return DoS(100, error("CTransaction::CheckTransaction() : txout.nValue too high
-            // (%zi)",txout.nValue));
+        if (txout.nValue > MAX_MONEY) {
+            DoS(100, false);
             return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-toolarge"));
+        }
 
         nValueOut += txout.nValue;
-        if (!MoneyRange(nValueOut))
-            // return DoS(100, error("CTransaction::CheckTransaction() : txout total out of range
-            // (%zi)",txout.nValue));
+        if (!MoneyRange(nValueOut)) {
+            DoS(100, false);
             return Err(
                 MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-txouttotal-toolarge"));
+        }
 
         // check cold staking enforcement (for delegations) and value out
         if (txout.scriptPubKey.IsPayToColdStaking()) {
-            if (!Params().IsColdStakingEnabled())
-                // return DoS(10, error("%s: cold staking not active", __func__));
+            if (!Params().IsColdStakingEnabled()) {
+                DoS(10, false);
                 return Err(
                     MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-coldstake-disabled"));
+            }
 
-            if (txout.nValue < Params().MinColdStakingAmount())
-                // return DoS(100, error("%s: dust amount (%zd) not allowed for cold
-                // staking. Min amount: %zd",
-                //                  __func__, txout.nValue,
-                // Params().MinColdStakingAmount()));
+            if (txout.nValue < Params().MinColdStakingAmount()) {
+                DoS(100, false);
                 return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS,
                                               "bad-txns-coldstake-low-amount"));
+            }
         }
     }
 
@@ -300,16 +301,16 @@ Result<void, TxValidationState> CTransaction::CheckTransaction(CBlock* sourceBlo
                 sourceBlockPtr->reject =
                     CBlock::CBlockReject(REJECT_INVALID, "bad-cb-length", sourceBlockPtr->GetHash());
             }
-            // return DoS(100, error("CTransaction::CheckTransaction() : coinbase script size is
-            // invalid"));
+            DoS(100, false);
             return Err(MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-cb-length"));
         }
     } else {
         for (const CTxIn& txin : vin)
-            if (txin.prevout.IsNull())
-                // return DoS(10, error("CTransaction::CheckTransaction() : prevout is null"));
+            if (txin.prevout.IsNull()) {
+                DoS(10, false);
                 return Err(
                     MakeInvalidTxState(TxValidationResult::TX_CONSENSUS, "bad-txns-prevout-null"));
+            }
     }
 
     return Ok();

--- a/wallet/transaction.cpp
+++ b/wallet/transaction.cpp
@@ -507,12 +507,13 @@ bool CTransaction::ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& 
             CTxIndex&     txindex = inputs[prevout.hash].first;
             CTransaction& txPrev  = inputs[prevout.hash].second;
 
-            if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.vSpent.size())
+            if (prevout.n >= txPrev.vout.size() || prevout.n >= txindex.vSpent.size()) {
                 return DoS(100, error("ConnectInputs() : %s prevout.n out of range %d %" PRIszu
                                       " %" PRIszu " prev tx %s\n%s",
                                       GetHash().ToString().c_str(), prevout.n, txPrev.vout.size(),
                                       txindex.vSpent.size(), prevout.hash.ToString().c_str(),
                                       txPrev.ToString().c_str()));
+            }
 
             // If prev is coinbase or coinstake, check that it's matured
             int nCbM = Params().CoinbaseMaturity();
@@ -536,10 +537,11 @@ bool CTransaction::ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& 
                 }
 
             // ppcoin: check transaction timestamp
-            if (txPrev.nTime > nTime)
+            if (txPrev.nTime > nTime) {
                 return DoS(
                     100,
                     error("ConnectInputs() : transaction timestamp earlier than input transaction"));
+            }
 
             // Check for negative or overflow input values
             nValueIn += txPrev.vout[prevout.n].nValue;
@@ -615,16 +617,18 @@ bool CTransaction::ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& 
                 return DoS(100, error("ConnectInputs() : %s nTxFee < 0", GetHash().ToString().c_str()));
 
             // enforce transaction fees for every block
-            if (nTxFee < GetMinFee())
+            if (nTxFee < GetMinFee()) {
                 return fBlock ? DoS(100,
                                     error("ConnectInputs() : %s not paying required fee=%s, paid=%s",
                                           GetHash().ToString().c_str(), FormatMoney(GetMinFee()).c_str(),
                                           FormatMoney(nTxFee).c_str()))
                               : false;
+            }
 
             nFees += nTxFee;
-            if (!MoneyRange(nFees))
+            if (!MoneyRange(nFees)) {
                 return DoS(100, error("ConnectInputs() : nFees out of range"));
+            }
         }
     }
 

--- a/wallet/transaction.cpp
+++ b/wallet/transaction.cpp
@@ -489,8 +489,8 @@ unsigned int CTransaction::GetP2SHSigOpCount(const MapPrevTx& inputs) const
     return nSigOps;
 }
 
-bool CTransaction::ConnectInputs(CTxDB& /*txdb*/, MapPrevTx inputs,
-                                 std::map<uint256, CTxIndex>& mapTestPool, const CDiskTxPos& posThisTx,
+bool CTransaction::ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool,
+                                 const CDiskTxPos&               posThisTx,
                                  const ConstCBlockIndexSmartPtr& pindexBlock, bool fBlock, bool fMiner,
                                  CBlock* sourceBlockPtr)
 {

--- a/wallet/transaction.cpp
+++ b/wallet/transaction.cpp
@@ -613,8 +613,9 @@ bool CTransaction::ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& 
 
             // Tally transaction fees
             CAmount nTxFee = nValueIn - GetValueOut();
-            if (nTxFee < 0)
+            if (nTxFee < 0) {
                 return DoS(100, error("ConnectInputs() : %s nTxFee < 0", GetHash().ToString().c_str()));
+            }
 
             // enforce transaction fees for every block
             if (nTxFee < GetMinFee()) {

--- a/wallet/transaction.cpp
+++ b/wallet/transaction.cpp
@@ -179,7 +179,7 @@ bool CTransaction::AreInputsStandard(const MapPrevTx& mapInputs) const
         // beside "push data" in the scriptSig the
         // IsStandard() call returns false
         std::vector<std::vector<unsigned char>> stack;
-        if (!EvalScript(stack, vin[i].scriptSig, *this, i, false, 0))
+        if (EvalScript(stack, vin[i].scriptSig, *this, i, false, 0).isErr())
             return false;
 
         if (whichType == TX_SCRIPTHASH) {

--- a/wallet/transaction.h
+++ b/wallet/transaction.h
@@ -10,6 +10,7 @@
 #include "txindex.h"
 #include "txout.h"
 #include "uint256.h"
+#include "validation.h"
 #include <vector>
 
 class CTransaction;
@@ -173,7 +174,7 @@ public:
     bool ConnectInputs(CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool,
                        const CDiskTxPos& posThisTx, const ConstCBlockIndexSmartPtr& pindexBlock,
                        bool fBlock, bool fMiner, CBlock* sourceBlockPtr = nullptr);
-    bool CheckTransaction(CBlock* sourceBlock = nullptr) const;
+    Result<void, TxValidationState> CheckTransaction(CBlock* sourceBlock = nullptr) const;
     bool GetCoinAge(CTxDB& txdb, uint64_t& nCoinAge) const; // ppcoin: get transaction coin age
 
     [[nodiscard]] static CTransaction FetchTxFromDisk(const uint256& txid);

--- a/wallet/transaction.h
+++ b/wallet/transaction.h
@@ -171,9 +171,10 @@ public:
         @param[in] fMiner	true if called from CreateNewBlock
         @return Returns true if all checks succeed
         */
-    bool ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool,
-                       const CDiskTxPos& posThisTx, const ConstCBlockIndexSmartPtr& pindexBlock,
-                       bool fBlock, bool fMiner, CBlock* sourceBlockPtr = nullptr);
+    Result<void, TxValidationState>
+                                    ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool,
+                                                  const CDiskTxPos& posThisTx, const ConstCBlockIndexSmartPtr& pindexBlock, bool fBlock,
+                                                  bool fMiner, CBlock* sourceBlockPtr = nullptr);
     Result<void, TxValidationState> CheckTransaction(CBlock* sourceBlock = nullptr) const;
     bool GetCoinAge(CTxDB& txdb, uint64_t& nCoinAge) const; // ppcoin: get transaction coin age
 

--- a/wallet/transaction.h
+++ b/wallet/transaction.h
@@ -171,7 +171,7 @@ public:
         @param[in] fMiner	true if called from CreateNewBlock
         @return Returns true if all checks succeed
         */
-    bool ConnectInputs(CTxDB& txdb, MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool,
+    bool ConnectInputs(MapPrevTx inputs, std::map<uint256, CTxIndex>& mapTestPool,
                        const CDiskTxPos& posThisTx, const ConstCBlockIndexSmartPtr& pindexBlock,
                        bool fBlock, bool fMiner, CBlock* sourceBlockPtr = nullptr);
     Result<void, TxValidationState> CheckTransaction(CBlock* sourceBlock = nullptr) const;

--- a/wallet/txdb-lmdb.cpp
+++ b/wallet/txdb-lmdb.cpp
@@ -1174,7 +1174,7 @@ bool CTxDB::LoadBlockIndex()
                                                "of %s:%i from disk\n",
                                                hashTx.ToString().c_str(), nOutput);
                                         pindexFork = pindex->pprev;
-                                    } else if (!txSpend.CheckTransaction()) {
+                                    } else if (txSpend.CheckTransaction().isErr()) {
                                         printf("LoadBlockIndex(): *** spending transaction of %s:%i is "
                                                "invalid\n",
                                                hashTx.ToString().c_str(), nOutput);

--- a/wallet/validation.cpp
+++ b/wallet/validation.cpp
@@ -1,0 +1,1 @@
+#include "validation.h"

--- a/wallet/validation.h
+++ b/wallet/validation.h
@@ -38,6 +38,9 @@ enum class TxValidationResult {
      */
     TX_CONFLICT,
     TX_MEMPOOL_POLICY,        //!< violated mempool's fee/size/descendant/RBF/etc limits
+    TX_INVALID_INPUTS,
+    TX_INPUT_CONNECT_FAILED,
+    TX_NTP1_ERROR,
 };
 
 /** A "reason" why a block was invalid, suitable for determining whether the

--- a/wallet/validation.h
+++ b/wallet/validation.h
@@ -1,0 +1,135 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONSENSUS_VALIDATION_H
+#define BITCOIN_CONSENSUS_VALIDATION_H
+
+#include <string>
+
+/** A "reason" why a transaction was invalid, suitable for determining whether the
+  * provider of the transaction should be banned/ignored/disconnected/etc.
+  */
+enum class TxValidationResult {
+    TX_RESULT_UNSET = 0,     //!< initial value. Tx has not yet been rejected
+    TX_CONSENSUS,            //!< invalid by consensus rules
+    /**
+     * Invalid by a change to consensus rules more recent than SegWit.
+     * Currently unused as there are no such consensus rule changes, and any download
+     * sources realistically need to support SegWit in order to provide useful data,
+     * so differentiating between always-invalid and invalid-by-pre-SegWit-soft-fork
+     * is uninteresting.
+     */
+    TX_RECENT_CONSENSUS_CHANGE,
+    TX_NOT_STANDARD,          //!< didn't meet our local policy rules
+    TX_MISSING_INPUTS,        //!< transaction was missing some of its inputs
+    TX_PREMATURE_SPEND,       //!< transaction spends a coinbase too early, or violates locktime/sequence locks
+    /**
+     * Transaction might be missing a witness, have a witness prior to SegWit
+     * activation, or witness may have been malleated (which includes
+     * non-standard witnesses).
+     */
+    TX_WITNESS_MUTATED,
+    /**
+     * Tx already in mempool or conflicts with a tx in the chain
+     * (if it conflicts with another tx in mempool, we use MEMPOOL_POLICY as it failed to reach the RBF threshold)
+     * Currently this is only used if the transaction already exists in the mempool or on chain.
+     */
+    TX_CONFLICT,
+    TX_MEMPOOL_POLICY,        //!< violated mempool's fee/size/descendant/RBF/etc limits
+};
+
+/** A "reason" why a block was invalid, suitable for determining whether the
+  * provider of the block should be banned/ignored/disconnected/etc.
+  * These are much more granular than the rejection codes, which may be more
+  * useful for some other use-cases.
+  */
+enum class BlockValidationResult {
+    BLOCK_RESULT_UNSET = 0,  //!< initial value. Block has not yet been rejected
+    BLOCK_CONSENSUS,         //!< invalid by consensus rules (excluding any below reasons)
+    /**
+     * Invalid by a change to consensus rules more recent than SegWit.
+     * Currently unused as there are no such consensus rule changes, and any download
+     * sources realistically need to support SegWit in order to provide useful data,
+     * so differentiating between always-invalid and invalid-by-pre-SegWit-soft-fork
+     * is uninteresting.
+     */
+    BLOCK_RECENT_CONSENSUS_CHANGE,
+    BLOCK_CACHED_INVALID,    //!< this block was cached as being invalid and we didn't store the reason why
+    BLOCK_INVALID_HEADER,    //!< invalid proof of work or time too old
+    BLOCK_MUTATED,           //!< the block's data didn't match the data committed to by the PoW
+    BLOCK_MISSING_PREV,      //!< We don't have the previous block the checked one is built on
+    BLOCK_INVALID_PREV,      //!< A block this one builds on is invalid
+    BLOCK_TIME_FUTURE,       //!< block timestamp was > 2 hours in the future (or our clock is bad)
+    BLOCK_CHECKPOINT,        //!< the block failed to meet one of our checkpoints
+};
+
+
+/** Template for capturing information about block/transaction validation. This is instantiated
+ *  by TxValidationState and BlockValidationState for validation information on transactions
+ *  and blocks respectively. */
+template <typename Result, typename Parent>
+class ValidationState {
+private:
+    enum mode_state {
+        MODE_VALID,   //!< everything ok
+        MODE_INVALID, //!< network rule violation (DoS value may be set)
+        MODE_ERROR,   //!< run-time error
+    } m_mode{MODE_VALID};
+    Result m_result{};
+    std::string m_reject_reason;
+    std::string m_debug_message;
+public:
+
+    using ResultType = Result;
+
+    void Invalid(Result result,
+                 const std::string &reject_reason="",
+                 const std::string &debug_message="")
+    {
+        m_result = result;
+        m_reject_reason = reject_reason;
+        m_debug_message = debug_message;
+        if (m_mode != MODE_ERROR) m_mode = MODE_INVALID;
+    }
+    void Error(const std::string& reject_reason)
+    {
+        if (m_mode == MODE_VALID)
+            m_reject_reason = reject_reason;
+        m_mode = MODE_ERROR;
+    }
+    bool IsValid() const { return m_mode == MODE_VALID; }
+    bool IsInvalid() const { return m_mode == MODE_INVALID; }
+    bool IsError() const { return m_mode == MODE_ERROR; }
+    Result GetResult() const { return m_result; }
+    std::string GetRejectReason() const { return m_reject_reason; }
+    std::string GetDebugMessage() const { return m_debug_message; }
+    std::string ToString() const
+    {
+        if (IsValid()) {
+            return "Valid";
+        }
+
+        if (!m_debug_message.empty()) {
+            return m_reject_reason + ", " + m_debug_message;
+        }
+
+        return m_reject_reason;
+    }
+};
+
+class TxValidationState : public ValidationState<TxValidationResult, TxValidationState> {};
+class BlockValidationState : public ValidationState<BlockValidationResult, BlockValidationState> {};
+
+inline TxValidationState MakeInvalidTxState(TxValidationState::ResultType result,
+                                     const std::string &reject_reason="",
+                                     const std::string &debug_message="")
+{
+    TxValidationState ret;
+    ret.Invalid(result, reject_reason, debug_message);
+    return ret;
+}
+
+
+#endif // BITCOIN_CONSENSUS_VALIDATION_H

--- a/wallet/wallet.cpp
+++ b/wallet/wallet.cpp
@@ -1169,7 +1169,7 @@ void CWallet::ResendWalletTransactions(bool fForce)
         }
         for (PAIRTYPE(const unsigned int, CWalletTx*) & item : mapSorted) {
             CWalletTx& wtx = *item.second;
-            if (wtx.CheckTransaction())
+            if (wtx.CheckTransaction().isOk())
                 wtx.RelayWalletTransaction();
             else
                 printf("ResendWalletTransactions() : CheckTransaction failed for transaction %s\n",

--- a/wallet/wallet.pri
+++ b/wallet/wallet.pri
@@ -164,7 +164,9 @@ HEADERS += qt/bitcoingui.h \
     wallet_ismine.h            \
     stakemaker.h               \
     addressbook.h              \
-    work.h
+    work.h                     \
+    validation.h               \
+    script_error.h
 
 
 
@@ -324,7 +326,10 @@ SOURCES += qt/bitcoin.cpp \
     wallet_ismine.cpp                   \
     stakemaker.cpp                      \
     addressbook.cpp                     \
-    work.cpp
+    work.cpp                            \
+    validation.cpp                      \
+    script_error.cpp
+
 
 
 

--- a/wallet/walletdb.cpp
+++ b/wallet/walletdb.cpp
@@ -310,7 +310,7 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, CW
             ssKey >> hash;
             CWalletTx& wtx = pwallet->mapWallet[hash];
             ssValue >> wtx;
-            if (wtx.CheckTransaction() && (wtx.GetHash() == hash))
+            if (wtx.CheckTransaction().isOk() && (wtx.GetHash() == hash))
                 wtx.BindWallet(pwallet);
             else {
                 pwallet->mapWallet.erase(hash);


### PR DESCRIPTION
This PR contains the first step into moving into ValidationState error codes to handle consensus errors. The idea of validation state is taken from Bitcoin, however, unfortunately bitcoin uses a very bad way of handling it, which is passing stateful mutable objects into functions to return information. In neblio, since we believe in stateless programming in the interest of security, I used a rust-like Result<T,E> to return the result of many functions that handle consensus. The ValidationState objects are created in these functions, and are returned to the caller with information on what went wrong.

We have to note that this is still incomplete. The purpose of this PR is to have enough implementation to be able to detect cold-staking errors in an accurate way, which requires passing errors from script evaluation all the way to `AcceptToMemoryPool()` function. Unfortunately, neblio still handles DoS issues using the old way, which is by containing the ban score of DoS inside CTransaction and CBlock objects. This is bad because it forces these objects to be passed in mutable form, which is, again, against the principles of safe programming. Bitcoin uses a single function to determine the DoS score for banning by passing the ValidationState object to it, which is also how we would like to have it. This PR is a step towards that, but we're still using the old DoS system. We'll incrementally reach that.

When reviewing this PR, it's very important to ensure that DoS scores are not changed, and that errors that share the same error codes (first parameter of `MakeInvalidTxState()`) have the same ban score coming with them (in preparation to moving to ban score vs error code in the future). Most importantly, we do not want to have any behavioral changes in the program other than different error messages, that are now passed successfully to regtests. We should ensure that no behavioral changes happened.

Later, we'll move more and more error handling towards ValidationState to improve the process of handling errors for consensus.