### PR TITLE
Make the "tokens" json node always show up in all RPC responses

### DIFF
--- a/wallet/rpcrawtransaction.cpp
+++ b/wallet/rpcrawtransaction.cpp
@@ -89,9 +89,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry, bo
             }
         }
         in.push_back(Pair("sequence", (int64_t)txin.nSequence));
-        if (isNTP1 && !ignoreNTP1) {
-            in.push_back(Pair("tokens", tokens));
-        }
+        in.push_back(Pair("tokens", tokens));
         vin.push_back(in);
     }
     entry.push_back(Pair("vin", vin));
@@ -113,8 +111,8 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, Object& entry, bo
                 n.get_obj().push_back(json_spirit::Pair("metadataOfIssuance", issuanceJson));
                 tokens.push_back(n);
             }
-            out.push_back(Pair("tokens", tokens));
         }
+        out.push_back(Pair("tokens", tokens));
         vout.push_back(out);
     }
     entry.push_back(Pair("vout", vout));


### PR DESCRIPTION
Make the "tokens" json node always show up in all RPC responses, whether there's or there's not NTP1 tokens

Closes #272 