### PR TITLE
Fix lmdb issues with non-ascii data directories

### DIFF
--- a/wallet/txdb-lmdb.cpp
+++ b/wallet/txdb-lmdb.cpp
@@ -408,7 +408,7 @@ bool ShouldQuickSyncBeDone(const filesystem::path& dbdir)
 void CTxDB::init_blockindex(bool fRemoveOld)
 {
     // First time init.
-    filesystem::path directory = GetDataDir() / DB_DIR;
+    const filesystem::path directory = GetDataDir() / DB_DIR;
 
     if (fRemoveOld ||
         SC_CheckOperationOnRestartScheduleThenDeleteIt(SC_SCHEDULE_ON_RESTART_OPNAME__RESYNC)) {
@@ -506,7 +506,8 @@ void CTxDB::init_blockindex(bool fRemoveOld)
 
     mdb_env_set_maxdbs(dbEnv.get(), 20);
 
-    if (auto result = mdb_env_open(dbEnv.get(), directory.string().c_str(), /*MDB_NOTLS*/ 0, 0644)) {
+    if (auto result = mdb_env_open(dbEnv.get(), PossiblyWideStringToString(directory.native()).c_str(),
+                                   /*MDB_NOTLS*/ 0, 0644)) {
         throw std::runtime_error("Failed to open lmdb environment: " + std::to_string(result) +
                                  "; message: " + std::string(mdb_strerror(result)));
     }
@@ -1026,7 +1027,7 @@ bool CTxDB::LoadBlockIndex()
     vector<pair<int, CBlockIndex*>> vSortedByHeight;
     vSortedByHeight.reserve(mapBlockIndex.size());
     uiInterface.InitMessage("Building chain trust... (allocating memory...)");
-    for (const PAIRTYPE(uint256, CBlockIndexSmartPtr) & item : mapBlockIndex) {
+    for (const PAIRTYPE(const uint256, CBlockIndexSmartPtr) & item : mapBlockIndex) {
         CBlockIndex* pindex = item.second.get();
         vSortedByHeight.push_back(make_pair(pindex->nHeight, pindex));
     }

--- a/wallet/util.cpp
+++ b/wallet/util.cpp
@@ -510,6 +510,15 @@ void ParseParameters(int argc, const char* const argv[])
     }
 }
 
+/// These two functions convert a path to a string to be passed to lmdb, or any other legacy software
+/// that takes only c_str as argument
+string PossiblyWideStringToString(const string& str) { return str; }
+string PossiblyWideStringToString(const wstring& str)
+{
+    std::wstring_convert<std::codecvt_utf8<wstring::value_type>, wstring::value_type> cv;
+    return cv.to_bytes(str);
+}
+
 std::string GetArg(const std::string& strArg, const std::string& strDefault)
 {
     return mapArgs.get(strArg).value_or(strDefault);

--- a/wallet/util.h
+++ b/wallet/util.h
@@ -31,6 +31,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/thread.hpp>
+#include <codecvt> // std::codecvt_utf8
 #include <openssl/md5.h>
 #include <openssl/ripemd.h>
 #include <openssl/sha.h>
@@ -223,6 +224,10 @@ boost::filesystem::path        GetDefaultDataDir();
 const boost::filesystem::path& GetDataDir(bool fNetSpecific = true);
 boost::filesystem::path        GetConfigFile();
 boost::filesystem::path        GetPidFile();
+
+std::string PossiblyWideStringToString(const std::string& str);
+std::string PossiblyWideStringToString(const std::wstring& str);
+
 #ifndef WIN32
 void CreatePidFile(const boost::filesystem::path& path, pid_t pid);
 #endif


### PR DESCRIPTION
lmdb doesn't support `boost::filesystem::path` or `std::wstring`. So we had to do some conversions to make it work. 