### PR TITLE
Fix a few things for NTP1 and system tests

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -204,7 +204,7 @@ class BitcoinTestFramework():
         if hasattr(self, "extra_args"):
             extra_args = self.extra_args
         self.add_nodes(self.num_nodes, extra_args)
-        self.start_nodes()
+        self.start_nodes(extra_args)
 
     def run_test(self):
         """Tests must override this method to define test logic"""

--- a/wallet/NetworkForks.cpp
+++ b/wallet/NetworkForks.cpp
@@ -23,3 +23,59 @@ bool NetworkForks::isForkActivated(NetworkFork fork) const
 }
 
 int NetworkForks::getFirstBlockOfFork(NetworkFork fork) const { return forksToBlockMap.at(fork); }
+
+boost::container::flat_map<std::string, NetworkFork>
+InvertNetworkForkEnumToName(const boost::container::flat_map<NetworkFork, std::string>& theMap)
+{
+    boost::container::flat_map<std::string, NetworkFork> result;
+    for (const auto& p : theMap) {
+        result[p.second] = p.first;
+    }
+    if (result.size() != theMap.size()) {
+        throw std::runtime_error("Invalid NetworkForkEnumToName map. There seems to be duplicates");
+    }
+    return result;
+}
+
+boost::optional<NetworkFork> GetNetworkForkByName(const std::string& networkFork)
+{
+    auto it = NetworkForkNameToEnum.find(networkFork);
+    if (it == NetworkForkNameToEnum.cend()) {
+        return boost::none;
+    }
+    return it->second;
+}
+
+const boost::container::flat_map<NetworkFork, int>
+ParseForkHeightsArgs(const std::vector<std::string>& args)
+{
+    boost::container::flat_map<NetworkFork, int> result;
+
+    for (const std::string& arg : args) {
+        // we expect every arg to be in the form: forkName,forkHeight. For example: tachyon,200
+
+        // split for commas
+        std::vector<std::string> splitRes;
+        boost::algorithm::split(splitRes, arg, boost::is_any_of(","), boost::token_compress_on);
+        if (splitRes.size() != 2) {
+            throw std::invalid_argument("Splitting fork height for ',' must have 2 elements");
+        }
+        const std::string& forkName   = splitRes[0];
+        const int          forkHeight = std::stoi(splitRes[1]);
+
+        // get fork from its name that we got from the arg
+        const boost::optional<NetworkFork> fork = GetNetworkForkByName(forkName);
+        if (!fork) {
+            throw std::invalid_argument("Invalid fork name in argument. Fork name '" + forkName +
+                                        "' is not recognized.");
+        }
+
+        // ensure we have no duplicates and save the result
+        if (result.find(*fork) != result.cend()) {
+            throw std::invalid_argument("Duplicate fork name; the fork '" + forkName +
+                                        "' appeared more than once.");
+        }
+        result[*fork] = forkHeight;
+    }
+    return result;
+}

--- a/wallet/NetworkForks.h
+++ b/wallet/NetworkForks.h
@@ -1,8 +1,13 @@
 #ifndef NETWORKFORKS_H
 #define NETWORKFORKS_H
 
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include <boost/atomic.hpp>
 #include <boost/container/flat_map.hpp>
+#include <boost/optional.hpp>
+#include <string>
+#include <vector>
 
 enum NetworkFork : uint16_t
 {
@@ -12,6 +17,24 @@ enum NetworkFork : uint16_t
     NETFORK__4_RETARGET_CORRECTION,
     NETFORK__5_COLD_STAKING
 };
+
+boost::container::flat_map<std::string, NetworkFork>
+InvertNetworkForkEnumToName(const boost::container::flat_map<NetworkFork, std::string>& theMap);
+
+boost::optional<NetworkFork> GetNetworkForkByName(const std::string& networkFork);
+
+const boost::container::flat_map<NetworkFork, std::string> NetworkForkEnumToName{
+    {NETFORK__1_FIRST_ONE, "first"},
+    {NETFORK__2_CONFS_CHANGE, "confs_changed"},
+    {NETFORK__3_TACHYON, "tachyon"},
+    {NETFORK__4_RETARGET_CORRECTION, "retarget_correction"},
+    {NETFORK__5_COLD_STAKING, "cold_staking"}};
+
+const boost::container::flat_map<std::string, NetworkFork> NetworkForkNameToEnum =
+    InvertNetworkForkEnumToName(NetworkForkEnumToName);
+
+const boost::container::flat_map<NetworkFork, int>
+ParseForkHeightsArgs(const std::vector<std::string>& args);
 
 class NetworkForks
 {

--- a/wallet/block.cpp
+++ b/wallet/block.cpp
@@ -1275,8 +1275,11 @@ bool CBlock::CheckBlock(bool fCheckPOW, bool fCheckMerkleRoot, bool fCheckSig)
     for (unsigned i = 0; i < vtx.size(); i++) {
         const CTransaction& tx = vtx[i];
 
-        if (tx.CheckTransaction(this).isErr())
-            return DoS(tx.nDoS, error("CheckBlock() : CheckTransaction failed"));
+        const auto checkTxResult = tx.CheckTransaction(this);
+        if (checkTxResult.isErr())
+            return DoS(tx.nDoS, error("CheckBlock() : CheckTransaction failed: (Msg: %s) - (Debug: %s)",
+                                      checkTxResult.unwrapErr().GetRejectReason().c_str(),
+                                      checkTxResult.unwrapErr().GetDebugMessage().c_str()));
 
         // ppcoin: check transaction timestamp
         if (GetBlockTime() < (int64_t)tx.nTime)

--- a/wallet/init.cpp
+++ b/wallet/init.cpp
@@ -1019,6 +1019,8 @@ bool AppInit2()
         pwalletMain->ReacceptWalletTransactions(true);
     }
 
+    appInitiated = true;
+
 #if !defined(QT_GUI)
     // Loop until process is exit()ed from shutdown() function,
     // called from ThreadRPCServer thread when a "stop" command is received.

--- a/wallet/itxdb.h
+++ b/wallet/itxdb.h
@@ -21,34 +21,34 @@ class ITxDB
 public:
     virtual ~ITxDB() = default;
 
-    virtual boost::optional<int> ReadVersion()                                                       = 0;
-    virtual bool                 WriteVersion(int nVersion)                                          = 0;
-    virtual bool                 ReadTxIndex(const uint256& hash, CTxIndex& txindex)                 = 0;
-    virtual bool                 UpdateTxIndex(const uint256& hash, const CTxIndex& txindex)         = 0;
-    virtual bool                 ReadTx(const CDiskTxPos& txPos, CTransaction& tx)                   = 0;
-    virtual bool                 ReadNTP1Tx(const uint256& hash, NTP1Transaction& ntp1tx)            = 0;
-    virtual bool                 WriteNTP1Tx(const uint256& hash, const NTP1Transaction& ntp1tx)     = 0;
-    virtual bool                 ReadAllIssuanceTxs(std::vector<uint256>& txs)                       = 0;
-    virtual bool ReadNTP1TxsWithTokenSymbol(const std::string& tokenName, std::vector<uint256>& txs) = 0;
-    virtual bool WriteNTP1TxWithTokenSymbol(const std::string& tokenName, const NTP1Transaction& tx) = 0;
-    virtual bool ReadAddressPubKey(const CBitcoinAddress& address, std::vector<uint8_t>& pubkey)     = 0;
+    virtual boost::optional<int> ReadVersion()                                                   = 0;
+    virtual bool                 WriteVersion(int nVersion)                                      = 0;
+    virtual bool                 ReadTxIndex(const uint256& hash, CTxIndex& txindex)             = 0;
+    virtual bool                 UpdateTxIndex(const uint256& hash, const CTxIndex& txindex)     = 0;
+    virtual bool                 ReadTx(const CDiskTxPos& txPos, CTransaction& tx)               = 0;
+    virtual bool                 ReadNTP1Tx(const uint256& hash, NTP1Transaction& ntp1tx)        = 0;
+    virtual bool                 WriteNTP1Tx(const uint256& hash, const NTP1Transaction& ntp1tx) = 0;
+    virtual bool                 ReadAllIssuanceTxs(std::vector<uint256>& txs)                   = 0;
+    virtual bool ReadNTP1TxsWithTokenSymbol(std::string tokenName, std::vector<uint256>& txs)    = 0;
+    virtual bool WriteNTP1TxWithTokenSymbol(std::string tokenName, const NTP1Transaction& tx)    = 0;
+    virtual bool ReadAddressPubKey(const CBitcoinAddress& address, std::vector<uint8_t>& pubkey) = 0;
     virtual bool WriteAddressPubKey(const CBitcoinAddress&      address,
-                                    const std::vector<uint8_t>& pubkey)                              = 0;
-    virtual bool EraseTxIndex(const uint256& hash)                                                   = 0;
-    virtual bool ContainsTx(const uint256& hash)                                                     = 0;
-    virtual bool ContainsNTP1Tx(const uint256& hash)                                                 = 0;
-    virtual bool ReadDiskTx(const uint256& hash, CTransaction& tx, CTxIndex& txindex)                = 0;
-    virtual bool ReadDiskTx(const uint256& hash, CTransaction& tx)                                   = 0;
-    virtual bool ReadDiskTx(const COutPoint& outpoint, CTransaction& tx, CTxIndex& txindex)          = 0;
-    virtual bool ReadDiskTx(const COutPoint& outpoint, CTransaction& tx)                             = 0;
-    virtual bool ReadBlock(const uint256& hash, CBlock& blk, bool fReadTransactions = true)          = 0;
-    virtual bool WriteBlock(const uint256& hash, const CBlock& blk)                                  = 0;
-    virtual bool WriteBlockIndex(const CDiskBlockIndex& blockindex)                                  = 0;
-    virtual bool ReadHashBestChain(uint256& hashBestChain)                                           = 0;
-    virtual bool WriteHashBestChain(const uint256& hashBestChain)                                    = 0;
-    virtual bool ReadBestInvalidTrust(CBigNum& bnBestInvalidTrust)                                   = 0;
-    virtual bool WriteBestInvalidTrust(const CBigNum& bnBestInvalidTrust)                            = 0;
-    virtual bool LoadBlockIndex()                                                                    = 0;
+                                    const std::vector<uint8_t>& pubkey)                          = 0;
+    virtual bool EraseTxIndex(const uint256& hash)                                               = 0;
+    virtual bool ContainsTx(const uint256& hash)                                                 = 0;
+    virtual bool ContainsNTP1Tx(const uint256& hash)                                             = 0;
+    virtual bool ReadDiskTx(const uint256& hash, CTransaction& tx, CTxIndex& txindex)            = 0;
+    virtual bool ReadDiskTx(const uint256& hash, CTransaction& tx)                               = 0;
+    virtual bool ReadDiskTx(const COutPoint& outpoint, CTransaction& tx, CTxIndex& txindex)      = 0;
+    virtual bool ReadDiskTx(const COutPoint& outpoint, CTransaction& tx)                         = 0;
+    virtual bool ReadBlock(const uint256& hash, CBlock& blk, bool fReadTransactions = true)      = 0;
+    virtual bool WriteBlock(const uint256& hash, const CBlock& blk)                              = 0;
+    virtual bool WriteBlockIndex(const CDiskBlockIndex& blockindex)                              = 0;
+    virtual bool ReadHashBestChain(uint256& hashBestChain)                                       = 0;
+    virtual bool WriteHashBestChain(const uint256& hashBestChain)                                = 0;
+    virtual bool ReadBestInvalidTrust(CBigNum& bnBestInvalidTrust)                               = 0;
+    virtual bool WriteBestInvalidTrust(const CBigNum& bnBestInvalidTrust)                        = 0;
+    virtual bool LoadBlockIndex()                                                                = 0;
 };
 
 #endif // ITXDB_H

--- a/wallet/main.cpp
+++ b/wallet/main.cpp
@@ -356,10 +356,10 @@ bool IsIssuedTokenBlacklisted(std::pair<CTransaction, NTP1Transaction>& txPair)
     return Params().IsNTP1TokenBlacklisted(storedTokenId);
 }
 
-void AssertNTP1TokenNameIsNotAlreadyInMainChain(std::string sym, const uint256& txHash, CTxDB& txdb)
+void AssertNTP1TokenNameIsNotAlreadyInMainChain(const std::string& sym, const uint256& txHash,
+                                                CTxDB& txdb)
 {
     // make sure that case doesn't matter by converting to upper case
-    std::transform(sym.begin(), sym.end(), sym.begin(), ::toupper);
     std::vector<uint256> storedSymbolsTxHashes;
     if (txdb.ReadNTP1TxsWithTokenSymbol(sym, storedSymbolsTxHashes)) {
         for (const uint256& h : storedSymbolsTxHashes) {
@@ -375,7 +375,7 @@ void AssertNTP1TokenNameIsNotAlreadyInMainChain(std::string sym, const uint256& 
             }
             // make sure that case doesn't matter by converting to upper case
             std::transform(storedSymbol.begin(), storedSymbol.end(), storedSymbol.begin(), ::toupper);
-            if (sym == storedSymbol && txHash != h) {
+            if (AreTokenSymbolsEquivalent(sym, storedSymbol) && txHash != h) {
                 throw std::runtime_error(
                     "Failed to accept issuance of token " + sym + " from transaction " +
                     txHash.ToString() +

--- a/wallet/main.h
+++ b/wallet/main.h
@@ -149,7 +149,8 @@ CDiskTxPos CreateFakeSpentTxPos(const uint256& blockhash);
 /** blacklisted tokens are tokens that are to be ignored and not used for historical reasons */
 bool IsIssuedTokenBlacklisted(std::pair<CTransaction, NTP1Transaction>& txPair);
 
-void AssertNTP1TokenNameIsNotAlreadyInMainChain(std::string sym, const uint256& txHash, CTxDB& txdb);
+void AssertNTP1TokenNameIsNotAlreadyInMainChain(const std::string& sym, const uint256& txHash,
+                                                CTxDB& txdb);
 void AssertNTP1TokenNameIsNotAlreadyInMainChain(const NTP1Transaction& ntp1tx, CTxDB& txdb);
 
 /** this function solves the problem of blocks having inputs from the same block. To process transactions

--- a/wallet/ntp1/ntp1transaction.cpp
+++ b/wallet/ntp1/ntp1transaction.cpp
@@ -1078,3 +1078,10 @@ bool NTP1Transaction::IsTxOutputOpRet(const CTxOut* output, std::string* opRetur
     }
     return false;
 }
+
+bool AreTokenSymbolsEquivalent(std::string lhs, std::string rhs)
+{
+    std::transform(lhs.begin(), lhs.end(), lhs.begin(), ::toupper);
+    std::transform(rhs.begin(), rhs.end(), rhs.begin(), ::toupper);
+    return lhs == rhs;
+}

--- a/wallet/ntp1/ntp1transaction.h
+++ b/wallet/ntp1/ntp1transaction.h
@@ -31,6 +31,8 @@ struct TokenMinimalData
     TokenMinimalData() : amount(0) {}
 };
 
+bool AreTokenSymbolsEquivalent(std::string lhs, std::string rhs);
+
 /**
  * @brief The NTP1Transaction class
  * A single NTP1 transaction

--- a/wallet/qt/bitcoin.cpp
+++ b/wallet/qt/bitcoin.cpp
@@ -247,7 +247,6 @@ int main(int argc, char* argv[])
         guiref = &window;
         if (AppInit2()) {
             {
-                appInitiated = true;
                 // Put this in a block, so that the Model objects are cleaned up before
                 // calling Shutdown().
 

--- a/wallet/test/mocks/mtxdb.h
+++ b/wallet/test/mocks/mtxdb.h
@@ -12,10 +12,10 @@ struct mTxDB : public ITxDB
     MOCK_METHOD(bool, ReadNTP1Tx, (const uint256& hash, NTP1Transaction& ntp1tx), (override));
     MOCK_METHOD(bool, WriteNTP1Tx, (const uint256& hash, const NTP1Transaction& ntp1tx), (override));
     MOCK_METHOD(bool, ReadAllIssuanceTxs, (std::vector<uint256> & txs), (override));
-    MOCK_METHOD(bool, ReadNTP1TxsWithTokenSymbol,
-                (const std::string& tokenName, std::vector<uint256>& txs), (override));
-    MOCK_METHOD(bool, WriteNTP1TxWithTokenSymbol,
-                (const std::string& tokenName, const NTP1Transaction& tx), (override));
+    MOCK_METHOD(bool, ReadNTP1TxsWithTokenSymbol, (std::string tokenName, std::vector<uint256>& txs),
+                (override));
+    MOCK_METHOD(bool, WriteNTP1TxWithTokenSymbol, (std::string tokenName, const NTP1Transaction& tx),
+                (override));
     MOCK_METHOD(bool, ReadAddressPubKey, (const CBitcoinAddress& address, std::vector<uint8_t>& pubkey),
                 (override));
     MOCK_METHOD(bool, WriteAddressPubKey,

--- a/wallet/txdb-lmdb.cpp
+++ b/wallet/txdb-lmdb.cpp
@@ -752,12 +752,13 @@ bool CTxDB::ReadNTP1Tx(const uint256& hash, NTP1Transaction& ntp1tx)
     return Read(hash, ntp1tx, db_ntp1Tx);
 }
 
-bool CTxDB::ReadNTP1TxsWithTokenSymbol(const std::string& tokenName, std::vector<uint256>& txs)
+bool CTxDB::ReadNTP1TxsWithTokenSymbol(std::string tokenName, std::vector<uint256>& txs)
 {
+    std::transform(tokenName.begin(), tokenName.end(), tokenName.begin(), ::toupper);
     return ReadMultiple(tokenName, txs, false, db_ntp1tokenNames);
 }
 
-bool CTxDB::WriteNTP1TxWithTokenSymbol(const std::string& tokenSymbol, const NTP1Transaction& ntp1tx)
+bool CTxDB::WriteNTP1TxWithTokenSymbol(std::string tokenSymbol, const NTP1Transaction& ntp1tx)
 {
     if (ntp1tx.isNull()) {
         printf("Attempted to store token symbol information of token with given symbol %s",
@@ -777,6 +778,10 @@ bool CTxDB::WriteNTP1TxWithTokenSymbol(const std::string& tokenSymbol, const NTP
                ntp1tx.getTxHash().ToString().c_str(), tokenSymbol.c_str());
         return false;
     }
+
+    std::transform(tokenSymbol.begin(), tokenSymbol.end(), tokenSymbol.begin(), ::toupper);
+    std::transform(symbol.begin(), symbol.end(), symbol.begin(), ::toupper);
+
     if (symbol != tokenSymbol) {
         printf("While writing NTP1 tx for token names, the token name provided is not equal to the "
                "token name calculated: %s != %s",

--- a/wallet/txdb-lmdb.h
+++ b/wallet/txdb-lmdb.h
@@ -729,8 +729,8 @@ public:
     bool ReadNTP1Tx(const uint256& hash, NTP1Transaction& ntp1tx) override;
     bool WriteNTP1Tx(const uint256& hash, const NTP1Transaction& ntp1tx) override;
     bool ReadAllIssuanceTxs(std::vector<uint256>& txs) override;
-    bool ReadNTP1TxsWithTokenSymbol(const std::string& tokenName, std::vector<uint256>& txs) override;
-    bool WriteNTP1TxWithTokenSymbol(const std::string& tokenName, const NTP1Transaction& tx) override;
+    bool ReadNTP1TxsWithTokenSymbol(std::string tokenName, std::vector<uint256>& txs) override;
+    bool WriteNTP1TxWithTokenSymbol(std::string tokenName, const NTP1Transaction& tx) override;
     bool ReadAddressPubKey(const CBitcoinAddress& address, std::vector<uint8_t>& pubkey) override;
     bool WriteAddressPubKey(const CBitcoinAddress& address, const std::vector<uint8_t>& pubkey) override;
     bool EraseTxIndex(const uint256& hash) override;


### PR DESCRIPTION
1. Fix arguments for system tests being ignored
2. Add the possibility to set fork heights for regtest
3. Ensure that NTP1 token name checks are done only with uppercase
4. Fix the appInitiated flag to work also for nebliod, not only neblio-qt
5. Change database abstraction layer to capitalize NTP1 token names
before storing them in the database